### PR TITLE
[PER-10] web-manager-dashboard: unscheduled quotes + technicians sidebar

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthProvider, homePathForRole, useAuth } from './lib/auth';
 import { RequireAuth, RequireRole } from './components/RequireAuth';
 import { Login } from './routes/Login';
 import { ManagerHome } from './routes/ManagerHome';
+import { ManagerSchedule } from './routes/ManagerSchedule';
 import { TechnicianHome } from './routes/TechnicianHome';
 import { Inbox } from './routes/Inbox';
 import { NotFound } from './routes/NotFound';
@@ -25,6 +26,16 @@ export function App(): JSX.Element {
               <RequireAuth>
                 <RequireRole role="manager">
                   <ManagerHome />
+                </RequireRole>
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/manager/schedule"
+            element={
+              <RequireAuth>
+                <RequireRole role="manager">
+                  <ManagerSchedule />
                 </RequireRole>
               </RequireAuth>
             }

--- a/apps/web/src/components/QuoteCard.test.tsx
+++ b/apps/web/src/components/QuoteCard.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QuoteCard } from './QuoteCard';
+
+const baseQuote = {
+  id: 'q1',
+  title: 'Replace HVAC unit',
+  customerName: 'Alice Lin',
+  address: '12 Smith St, Sydney',
+  status: 'unscheduled' as const,
+};
+
+describe('QuoteCard', () => {
+  it('renders title, customer, and address', () => {
+    render(<QuoteCard quote={baseQuote} onAssign={() => {}} />);
+    expect(screen.getByText('Replace HVAC unit')).toBeInTheDocument();
+    expect(screen.getByText('Alice Lin')).toBeInTheDocument();
+    expect(screen.getByText('12 Smith St, Sydney')).toBeInTheDocument();
+  });
+
+  it('calls onAssign with the quote when Assign is clicked', async () => {
+    const user = userEvent.setup();
+    const onAssign = vi.fn();
+    render(<QuoteCard quote={baseQuote} onAssign={onAssign} />);
+    await user.click(screen.getByRole('button', { name: /assign/i }));
+    expect(onAssign).toHaveBeenCalledWith(baseQuote);
+  });
+});

--- a/apps/web/src/components/QuoteCard.tsx
+++ b/apps/web/src/components/QuoteCard.tsx
@@ -1,0 +1,36 @@
+import type { Quote } from '@brix/shared';
+
+type QuoteCardProps = {
+  quote: Quote;
+  onAssign: (quote: Quote) => void;
+};
+
+export function QuoteCard({ quote, onAssign }: QuoteCardProps) {
+  return (
+    <article className="card p-5 flex flex-col gap-3">
+      <div>
+        <h3 className="text-base font-semibold text-ink">{quote.title}</h3>
+        <p className="text-xs uppercase tracking-wider text-accent-purple-300 mt-1">
+          {quote.status}
+        </p>
+      </div>
+      <dl className="text-sm text-ink-muted space-y-1">
+        <div>
+          <dt className="sr-only">Customer</dt>
+          <dd>{quote.customerName}</dd>
+        </div>
+        <div>
+          <dt className="sr-only">Address</dt>
+          <dd className="text-ink-subtle">{quote.address}</dd>
+        </div>
+      </dl>
+      <button
+        type="button"
+        onClick={() => onAssign(quote)}
+        className="btn-primary self-start"
+      >
+        Assign
+      </button>
+    </article>
+  );
+}

--- a/apps/web/src/components/TechnicianList.test.tsx
+++ b/apps/web/src/components/TechnicianList.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TechnicianList } from './TechnicianList';
+
+const techs = [
+  { id: 't1', name: 'Sam Patel', email: 'sam@x.io', role: 'technician' as const },
+  { id: 't2', name: 'Riya Chen', email: 'riya@x.io', role: 'technician' as const },
+];
+
+describe('TechnicianList', () => {
+  it('renders each technician name', () => {
+    render(<TechnicianList technicians={techs} selectedId={null} onSelect={() => {}} />);
+    expect(screen.getByText('Sam Patel')).toBeInTheDocument();
+    expect(screen.getByText('Riya Chen')).toBeInTheDocument();
+  });
+
+  it('marks the selected technician with aria-pressed=true', () => {
+    render(<TechnicianList technicians={techs} selectedId="t2" onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: /sam patel/i })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: /riya chen/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('calls onSelect with the technician id on click', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<TechnicianList technicians={techs} selectedId={null} onSelect={onSelect} />);
+    await user.click(screen.getByRole('button', { name: /sam patel/i }));
+    expect(onSelect).toHaveBeenCalledWith('t1');
+  });
+
+  it('renders an empty-state message when there are no technicians', () => {
+    render(<TechnicianList technicians={[]} selectedId={null} onSelect={() => {}} />);
+    expect(screen.getByText(/no technicians/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/TechnicianList.tsx
+++ b/apps/web/src/components/TechnicianList.tsx
@@ -1,0 +1,42 @@
+import type { PublicUser } from '@brix/shared';
+
+type TechnicianListProps = {
+  technicians: PublicUser[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+};
+
+export function TechnicianList({ technicians, selectedId, onSelect }: TechnicianListProps) {
+  if (technicians.length === 0) {
+    return (
+      <p className="text-sm text-ink-subtle">
+        No technicians available yet.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-1">
+      {technicians.map((tech) => {
+        const isSelected = tech.id === selectedId;
+        return (
+          <li key={tech.id}>
+            <button
+              type="button"
+              aria-pressed={isSelected}
+              onClick={() => onSelect(tech.id)}
+              className={`w-full text-left rounded-md px-3 py-2 text-sm transition border ${
+                isSelected
+                  ? 'border-accent-purple-500 bg-accent-purple-500/10 text-ink shadow-glow'
+                  : 'border-transparent text-ink-muted hover:text-ink hover:bg-bg-elevated'
+              }`}
+            >
+              <span className="block font-medium">{tech.name}</span>
+              <span className="block text-xs text-ink-subtle">{tech.email}</span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/src/lib/queries.test.ts
+++ b/apps/web/src/lib/queries.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useTechnicians, useUnscheduledQuotes } from './queries';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('queries hooks', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('useTechnicians fetches /users?role=technician and returns data', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        { id: 't1', email: 'sam@x.io', name: 'Sam Patel', role: 'technician' },
+      ]),
+    );
+
+    const { result } = renderHook(() => useTechnicians());
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual([
+      { id: 't1', email: 'sam@x.io', name: 'Sam Patel', role: 'technician' },
+    ]);
+    expect(result.current.error).toBeNull();
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain('/users?role=technician');
+  });
+
+  it('useUnscheduledQuotes fetches /quotes?status=unscheduled and returns data', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 'q1',
+          title: 'Replace HVAC unit',
+          customerName: 'Alice Lin',
+          address: '12 Smith St',
+          status: 'unscheduled',
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useUnscheduledQuotes());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.[0]?.id).toBe('q1');
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain('/quotes?status=unscheduled');
+  });
+
+  it('exposes error when the request fails', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500));
+
+    const { result } = renderHook(() => useTechnicians());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import type { PublicUser, Quote } from '@brix/shared';
+import { apiClient } from './api';
+
+export type QueryState<T> = {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+};
+
+function useResource<T>(path: string): QueryState<T> {
+  const [state, setState] = useState<QueryState<T>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ data: null, loading: true, error: null });
+    apiClient
+      .get<T>(path)
+      .then((data) => {
+        if (cancelled) return;
+        setState({ data, loading: false, error: null });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({
+          data: null,
+          loading: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+
+  return state;
+}
+
+export function useTechnicians(): QueryState<PublicUser[]> {
+  return useResource<PublicUser[]>('/users?role=technician');
+}
+
+export function useUnscheduledQuotes(): QueryState<Quote[]> {
+  return useResource<Quote[]>('/quotes?status=unscheduled');
+}

--- a/apps/web/src/routes/ManagerHome.test.tsx
+++ b/apps/web/src/routes/ManagerHome.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { AUTH_STORAGE_KEY, AuthProvider } from '../lib/auth';
+import { ManagerHome } from './ManagerHome';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+const SAMPLE_TECHS = [
+  { id: 't1', email: 'sam@x.io', name: 'Sam Patel', role: 'technician' },
+  { id: 't2', email: 'riya@x.io', name: 'Riya Chen', role: 'technician' },
+];
+
+const SAMPLE_QUOTES = [
+  {
+    id: 'q1',
+    title: 'Replace HVAC unit',
+    customerName: 'Alice Lin',
+    address: '12 Smith St',
+    status: 'unscheduled',
+  },
+  {
+    id: 'q2',
+    title: 'Repair leaking faucet',
+    customerName: 'Bob Tran',
+    address: '8 Elm Rd',
+    status: 'unscheduled',
+  },
+];
+
+function ScheduleProbe() {
+  const loc = useLocation();
+  const state = loc.state as { quoteId?: string; technicianId?: string } | null;
+  return (
+    <div>
+      SCHEDULE PAGE quote={state?.quoteId ?? ''} tech={state?.technicianId ?? ''}
+    </div>
+  );
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function seedAuth() {
+  window.localStorage.setItem(
+    AUTH_STORAGE_KEY,
+    JSON.stringify({
+      token: 'jwt-mgr',
+      user: { id: 'mgr1', email: 'mgr@x.io', role: 'manager' },
+    }),
+  );
+}
+
+function mockListEndpoints(opts: { quotes?: unknown; techs?: unknown; quotesStatus?: number; techsStatus?: number } = {}) {
+  const fetchMock = vi.mocked(globalThis.fetch);
+  fetchMock.mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.includes('/quotes')) {
+      return Promise.resolve(jsonResponse(opts.quotes ?? SAMPLE_QUOTES, opts.quotesStatus ?? 200));
+    }
+    if (url.includes('/users')) {
+      return Promise.resolve(jsonResponse(opts.techs ?? SAMPLE_TECHS, opts.techsStatus ?? 200));
+    }
+    return Promise.resolve(jsonResponse({ error: 'unexpected url ' + url }, 500));
+  });
+}
+
+function Tree() {
+  return (
+    <MemoryRouter initialEntries={['/manager']}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/manager" element={<ManagerHome />} />
+          <Route path="/manager/schedule" element={<ScheduleProbe />} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('ManagerHome', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+    seedAuth();
+  });
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('renders technicians sidebar and unscheduled quote cards', async () => {
+    mockListEndpoints();
+    render(<Tree />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Sam Patel')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Riya Chen')).toBeInTheDocument();
+    expect(screen.getByText('Replace HVAC unit')).toBeInTheDocument();
+    expect(screen.getByText('Repair leaking faucet')).toBeInTheDocument();
+  });
+
+  it('shows loading state initially', () => {
+    mockListEndpoints();
+    render(<Tree />);
+    expect(screen.getAllByText(/loading/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows an empty state when there are no unscheduled quotes', async () => {
+    mockListEndpoints({ quotes: [] });
+    render(<Tree />);
+    await waitFor(() => {
+      expect(screen.getByText(/no unscheduled quotes/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error state if quotes fail to load', async () => {
+    mockListEndpoints({ quotes: { error: 'boom' }, quotesStatus: 500 });
+    render(<Tree />);
+    await waitFor(() => {
+      expect(screen.getByText(/couldn.?t load quotes/i)).toBeInTheDocument();
+    });
+  });
+
+  it('prompts when Assign is clicked without a selected technician', async () => {
+    const user = userEvent.setup();
+    mockListEndpoints();
+    render(<Tree />);
+
+    await waitFor(() => screen.getByText('Replace HVAC unit'));
+
+    const firstCard = screen.getByText('Replace HVAC unit').closest('article')!;
+    await user.click(within(firstCard).getByRole('button', { name: /assign/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/select a technician/i);
+  });
+
+  it('navigates to /manager/schedule with quote + technician state when Assign is clicked with a selection', async () => {
+    const user = userEvent.setup();
+    mockListEndpoints();
+    render(<Tree />);
+
+    await waitFor(() => screen.getByText('Sam Patel'));
+
+    await user.click(screen.getByRole('button', { name: /sam patel/i }));
+    expect(screen.getByRole('button', { name: /sam patel/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    const card = screen.getByText('Replace HVAC unit').closest('article')!;
+    await user.click(within(card).getByRole('button', { name: /assign/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/SCHEDULE PAGE quote=q1 tech=t1/)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/routes/ManagerHome.tsx
+++ b/apps/web/src/routes/ManagerHome.tsx
@@ -1,22 +1,91 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { Quote } from '@brix/shared';
 import { Layout } from '../components/Layout';
-import { useAuth } from '../lib/auth';
+import { QuoteCard } from '../components/QuoteCard';
+import { TechnicianList } from '../components/TechnicianList';
+import { useTechnicians, useUnscheduledQuotes } from '../lib/queries';
 
 export function ManagerHome() {
-  const { user } = useAuth();
+  const navigate = useNavigate();
+  const techs = useTechnicians();
+  const quotes = useUnscheduledQuotes();
+  const [selectedTechId, setSelectedTechId] = useState<string | null>(null);
+  const [prompt, setPrompt] = useState<string | null>(null);
+
+  const handleAssign = (quote: Quote) => {
+    if (!selectedTechId) {
+      setPrompt('Select a technician from the sidebar first.');
+      return;
+    }
+    setPrompt(null);
+    navigate('/manager/schedule', {
+      state: { quoteId: quote.id, technicianId: selectedTechId },
+    });
+  };
+
+  const handleSelectTech = (id: string) => {
+    setSelectedTechId(id);
+    if (prompt) setPrompt(null);
+  };
+
   return (
     <Layout>
       <header className="mb-6">
         <p className="text-xs uppercase tracking-widest text-accent-purple-400">Manager</p>
-        <h1 className="text-3xl font-semibold text-ink">Welcome, {user?.email}</h1>
+        <h1 className="text-3xl font-semibold text-ink">Schedule</h1>
         <p className="text-sm text-ink-muted mt-1">
-          Schedule jobs and track technician availability.
+          Pick a technician, then assign an unscheduled quote.
         </p>
       </header>
-      <div className="card p-6">
-        <p className="text-sm text-ink-muted">
-          Schedule view will land in a future change. This page exists so the auth + routing shell
-          can be exercised end to end.
-        </p>
+
+      {prompt ? (
+        <div
+          role="alert"
+          className="card p-3 mb-4 border-accent-purple-500/50 text-sm text-accent-purple-200"
+        >
+          {prompt}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 lg:grid-cols-[260px_minmax(0,1fr)] gap-6">
+        <aside className="card p-4 h-fit">
+          <h2 className="text-xs uppercase tracking-widest text-ink-subtle mb-3">
+            Technicians
+          </h2>
+          {techs.loading ? (
+            <p className="text-sm text-ink-subtle">Loading technicians…</p>
+          ) : techs.error ? (
+            <p className="text-sm text-red-300">Couldn&rsquo;t load technicians.</p>
+          ) : (
+            <TechnicianList
+              technicians={techs.data ?? []}
+              selectedId={selectedTechId}
+              onSelect={handleSelectTech}
+            />
+          )}
+        </aside>
+
+        <section>
+          <h2 className="text-xs uppercase tracking-widest text-ink-subtle mb-3">
+            Unscheduled quotes
+          </h2>
+          {quotes.loading ? (
+            <p className="text-sm text-ink-subtle">Loading quotes…</p>
+          ) : quotes.error ? (
+            <p className="text-sm text-red-300">Couldn&rsquo;t load quotes.</p>
+          ) : (quotes.data ?? []).length === 0 ? (
+            <div className="card p-6 text-sm text-ink-muted">
+              No unscheduled quotes right now.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {(quotes.data ?? []).map((q) => (
+                <QuoteCard key={q.id} quote={q} onAssign={handleAssign} />
+              ))}
+            </div>
+          )}
+        </section>
       </div>
     </Layout>
   );

--- a/apps/web/src/routes/ManagerSchedule.tsx
+++ b/apps/web/src/routes/ManagerSchedule.tsx
@@ -1,0 +1,35 @@
+import { Link, useLocation } from 'react-router-dom';
+import { Layout } from '../components/Layout';
+
+type ScheduleState = {
+  quoteId?: string;
+  technicianId?: string;
+};
+
+export function ManagerSchedule() {
+  const location = useLocation();
+  const state = (location.state ?? null) as ScheduleState | null;
+
+  return (
+    <Layout>
+      <header className="mb-6">
+        <p className="text-xs uppercase tracking-widest text-accent-purple-400">Manager</p>
+        <h1 className="text-3xl font-semibold text-ink">Schedule a job</h1>
+        <p className="text-sm text-ink-muted mt-1">
+          Calendar view lands in the next change. For now this confirms the assignment payload.
+        </p>
+      </header>
+      <div className="card p-6 text-sm text-ink-muted space-y-2">
+        <p>
+          <span className="text-ink-subtle">Quote:</span> {state?.quoteId ?? '—'}
+        </p>
+        <p>
+          <span className="text-ink-subtle">Technician:</span> {state?.technicianId ?? '—'}
+        </p>
+        <Link to="/manager" className="btn-ghost mt-2 inline-flex">
+          Back
+        </Link>
+      </div>
+    </Layout>
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,23 @@
 export type HealthStatus = {
   status: 'ok';
 };
+
+export type Role = 'manager' | 'technician';
+
+export type QuoteStatus = 'unscheduled' | 'scheduled' | 'completed' | 'cancelled';
+
+export type PublicUser = {
+  id: string;
+  email: string;
+  name: string;
+  role: Role;
+};
+
+export type Quote = {
+  id: string;
+  title: string;
+  description?: string | null;
+  customerName: string;
+  address: string;
+  status: QuoteStatus;
+};


### PR DESCRIPTION
Closes #9
Linear: https://linear.app/chuck-heya/issue/PER-10/web-manager-dashboard-unscheduled-quotes-technicians-sidebar

## Summary
Replaces the ManagerHome stub with a full two-column dashboard. The left sidebar renders technicians from `GET /users?role=technician` with selectable highlight state. The main area renders unscheduled quotes from `GET /quotes?status=unscheduled` as cards showing title, customer, and address. Clicking Assign without a selected technician shows an inline alert prompt; clicking with a selection navigates to `/manager/schedule` (placeholder route) carrying `{ quoteId, technicianId }` in location state for the upcoming calendar issue. Loading/error/empty states are handled for both data sources. Domain types `PublicUser` and `Quote` are now exported from `@brix/shared`.

## Tests
- Added: `QuoteCard.test.tsx`, `TechnicianList.test.tsx`, `queries.test.ts`, `ManagerHome.test.tsx`
- Status: 31 passing / 31 total

## Files touched
- `apps/web/src/routes/ManagerHome.tsx` — full dashboard implementation
- `apps/web/src/routes/ManagerSchedule.tsx` — placeholder calendar route
- `apps/web/src/components/QuoteCard.tsx` — quote card component
- `apps/web/src/components/TechnicianList.tsx` — sidebar technician list
- `apps/web/src/lib/queries.ts` — `useTechnicians` and `useUnscheduledQuotes` hooks
- `apps/web/src/App.tsx` — adds `/manager/schedule` route
- `packages/shared/src/index.ts` — exports `PublicUser`, `Quote`, `Role`, `QuoteStatus`

## Follow-ups
- Calendar UI: PER-11 (next issue)
- These hooks rely on PER-6 API endpoints to be live before end-to-end manual testing