### PR TITLE
[PER-7] jobs-api-with-conflict: POST/GET/PATCH jobs with overlap prevention

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import type { HealthStatus, UserRole } from '@brix/shared';
 import { createAuthRouter } from './routes/auth.js';
 import { quotesRouter } from './routes/quotes.js';
 import { usersRouter } from './routes/users.js';
+import { createJobsRouter, type JobsDeps } from './routes/jobs.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 export type UserRecord = {
@@ -18,7 +19,9 @@ export type AuthDeps = {
   findUserById: (id: string) => Promise<UserRecord | null>;
 };
 
-export function createApp(deps?: AuthDeps): Express {
+export type { JobsDeps };
+
+export function createApp(deps?: AuthDeps, jobsDeps?: JobsDeps): Express {
   const app = express();
   app.use(express.json());
 
@@ -33,6 +36,10 @@ export function createApp(deps?: AuthDeps): Express {
 
   app.use(quotesRouter);
   app.use(usersRouter);
+
+  if (jobsDeps) {
+    app.use('/jobs', createJobsRouter(jobsDeps));
+  }
 
   app.use(errorHandler);
 

--- a/apps/api/src/db/migrations/0002_notification_completed.sql
+++ b/apps/api/src/db/migrations/0002_notification_completed.sql
@@ -1,0 +1,3 @@
+-- Add 'job_completed' to the notification_type enum so technicians can notify
+-- the manager when they finish a job.
+ALTER TYPE "public"."notification_type" ADD VALUE IF NOT EXISTS 'job_completed';

--- a/apps/api/src/db/migrations/meta/0002_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,389 @@
+{
+  "id": "1b2c4d6e-8f10-4a23-9c45-67890abcdef0",
+  "prevId": "9d8576f0-3428-4b5f-bf43-77ea5ef8bca2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "technician_id": {
+          "name": "technician_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "jobs_quote_id_quotes_id_fk": {
+          "name": "jobs_quote_id_quotes_id_fk",
+          "tableFrom": "jobs",
+          "columnsFrom": [
+            "quote_id"
+          ],
+          "tableTo": "quotes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "jobs_technician_id_users_id_fk": {
+          "name": "jobs_technician_id_users_id_fk",
+          "tableFrom": "jobs",
+          "columnsFrom": [
+            "technician_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "jobs_manager_id_users_id_fk": {
+          "name": "jobs_manager_id_users_id_fk",
+          "tableFrom": "jobs",
+          "columnsFrom": [
+            "manager_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jobs_quote_id_unique": {
+          "name": "jobs_quote_id_unique",
+          "columns": [
+            "quote_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_recipient_user_id_users_id_fk": {
+          "name": "notifications_recipient_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notifications_job_id_jobs_id_fk": {
+          "name": "notifications_job_id_jobs_id_fk",
+          "tableFrom": "notifications",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "tableTo": "jobs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "quote_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unscheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "job_assigned",
+        "job_rescheduled",
+        "job_cancelled",
+        "job_completed"
+      ]
+    },
+    "public.quote_status": {
+      "name": "quote_status",
+      "schema": "public",
+      "values": [
+        "unscheduled",
+        "scheduled",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "manager",
+        "technician"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777625219009,
       "tag": "0001_jobs_no_overlap",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777625250000,
+      "tag": "0002_notification_completed",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.test.ts
+++ b/apps/api/src/db/schema.test.ts
@@ -85,6 +85,7 @@ describe('schema exports', () => {
       'job_assigned',
       'job_rescheduled',
       'job_cancelled',
+      'job_completed',
     ]);
   });
 });

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -24,6 +24,7 @@ export const notificationTypeEnum = pgEnum('notification_type', [
   'job_assigned',
   'job_rescheduled',
   'job_cancelled',
+  'job_completed',
 ]);
 
 export const users = pgTable('users', {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { createApp } from './app.js';
 import type { AuthDeps, UserRecord } from './app.js';
 import { db } from './db/client.js';
 import { users } from './db/schema.js';
+import { createJobAssignmentService } from './services/jobAssignment.js';
 
 const port = Number(process.env.PORT) || 3001;
 
@@ -36,7 +37,8 @@ function toUserRecord(row: typeof users.$inferSelect): UserRecord {
   };
 }
 
-const app = createApp(deps);
+const jobsService = createJobAssignmentService(db);
+const app = createApp(deps, jobsService);
 
 app.listen(port, () => {
   console.log(`api listening on http://localhost:${port}`);

--- a/apps/api/src/routes/jobs.test.ts
+++ b/apps/api/src/routes/jobs.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import bcrypt from 'bcryptjs';
-import { createApp } from '../app.js';
+
+vi.stubEnv('DATABASE_URL', 'postgresql://fake');
+vi.mock('../db/client.js', () => ({ db: { select: vi.fn() } }));
+
+const { createApp } = await import('../app.js');
 import type { AuthDeps, UserRecord, JobsDeps } from '../app.js';
 import type { Job, LoginResponse } from '@brix/shared';
 import { HttpError } from '../middleware/errorHandler.js';

--- a/apps/api/src/routes/jobs.test.ts
+++ b/apps/api/src/routes/jobs.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import bcrypt from 'bcryptjs';
+import { createApp } from '../app.js';
+import type { AuthDeps, UserRecord, JobsDeps } from '../app.js';
+import type { Job, LoginResponse } from '@brix/shared';
+import { HttpError } from '../middleware/errorHandler.js';
+
+const password = 'password123';
+
+const managerId = '11111111-1111-1111-1111-111111111111';
+const otherManagerId = '22222222-2222-2222-2222-222222222222';
+const techAId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const techBId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const quoteId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const jobId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+async function makeAuthDeps(): Promise<AuthDeps> {
+  const passwordHash = await bcrypt.hash(password, 4);
+  const manager: UserRecord = {
+    id: managerId,
+    email: 'mgr@brix.local',
+    name: 'Maya',
+    role: 'manager',
+    passwordHash,
+  };
+  const otherMgr: UserRecord = {
+    id: otherManagerId,
+    email: 'mgr2@brix.local',
+    name: 'Marc',
+    role: 'manager',
+    passwordHash,
+  };
+  const techA: UserRecord = {
+    id: techAId,
+    email: 'techa@brix.local',
+    name: 'Tara',
+    role: 'technician',
+    passwordHash,
+  };
+  const techB: UserRecord = {
+    id: techBId,
+    email: 'techb@brix.local',
+    name: 'Theo',
+    role: 'technician',
+    passwordHash,
+  };
+  const byEmail = new Map([
+    [manager.email, manager],
+    [otherMgr.email, otherMgr],
+    [techA.email, techA],
+    [techB.email, techB],
+  ]);
+  const byId = new Map([
+    [manager.id, manager],
+    [otherMgr.id, otherMgr],
+    [techA.id, techA],
+    [techB.id, techB],
+  ]);
+  return {
+    findUserByEmail: async (email) => byEmail.get(email) ?? null,
+    findUserById: async (id) => byId.get(id) ?? null,
+  };
+}
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: jobId,
+    quoteId,
+    technicianId: techAId,
+    managerId,
+    startTime: '2026-06-01T09:00:00.000Z',
+    endTime: '2026-06-01T11:00:00.000Z',
+    status: 'scheduled',
+    quote: {
+      id: quoteId,
+      title: 'Replace tap',
+      customerName: 'Alex',
+      address: '12 Carlton St',
+      status: 'scheduled',
+    },
+    ...overrides,
+  };
+}
+
+function makeJobsDeps(): JobsDeps {
+  return {
+    createJob: vi.fn(),
+    listJobs: vi.fn(),
+    patchJob: vi.fn(),
+  };
+}
+
+async function loginAs(app: ReturnType<typeof createApp>, email: string) {
+  const res = await request(app)
+    .post('/auth/login')
+    .send({ email, password });
+  return (res.body as LoginResponse).token;
+}
+
+describe('POST /jobs', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  it('returns 201 with job for valid manager request', async () => {
+    const job = makeJob();
+    const jobsDeps = makeJobsDeps();
+    (jobsDeps.createJob as ReturnType<typeof vi.fn>).mockResolvedValue(job);
+
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'mgr@brix.local');
+
+    const res = await request(app)
+      .post('/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        quoteId,
+        technicianId: techAId,
+        startTime: job.startTime,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.job).toEqual(job);
+    expect(jobsDeps.createJob).toHaveBeenCalledWith({
+      managerId,
+      quoteId,
+      technicianId: techAId,
+      startTime: job.startTime,
+    });
+  });
+
+  it('returns 403 when called by a technician', async () => {
+    const jobsDeps = makeJobsDeps();
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'techa@brix.local');
+
+    const res = await request(app)
+      .post('/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        quoteId,
+        technicianId: techAId,
+        startTime: '2026-06-01T09:00:00.000Z',
+      });
+
+    expect(res.status).toBe(403);
+    expect(jobsDeps.createJob).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 without a token', async () => {
+    const app = createApp(await makeAuthDeps(), makeJobsDeps());
+    const res = await request(app).post('/jobs').send({});
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 on missing fields', async () => {
+    const app = createApp(await makeAuthDeps(), makeJobsDeps());
+    const token = await loginAs(app, 'mgr@brix.local');
+    const res = await request(app)
+      .post('/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ quoteId });
+    expect(res.status).toBe(400);
+  });
+
+  it('translates 409 from service into 409 response', async () => {
+    const jobsDeps = makeJobsDeps();
+    (jobsDeps.createJob as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new HttpError(409, 'Technician already booked for this window'),
+    );
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'mgr@brix.local');
+
+    const res = await request(app)
+      .post('/jobs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        quoteId,
+        technicianId: techAId,
+        startTime: '2026-06-01T09:00:00.000Z',
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/booked|conflict/i);
+  });
+});
+
+describe('GET /jobs', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  it('manager can list any technician jobs', async () => {
+    const jobsDeps = makeJobsDeps();
+    (jobsDeps.listJobs as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makeJob(),
+    ]);
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'mgr@brix.local');
+
+    const res = await request(app)
+      .get(`/jobs?technicianId=${techAId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.jobs).toHaveLength(1);
+    expect(jobsDeps.listJobs).toHaveBeenCalledWith({
+      technicianId: techAId,
+    });
+  });
+
+  it('technician can list their own jobs', async () => {
+    const jobsDeps = makeJobsDeps();
+    (jobsDeps.listJobs as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'techa@brix.local');
+
+    const res = await request(app)
+      .get(`/jobs?technicianId=${techAId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('technician cannot list other technician jobs', async () => {
+    const jobsDeps = makeJobsDeps();
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'techa@brix.local');
+
+    const res = await request(app)
+      .get(`/jobs?technicianId=${techBId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+    expect(jobsDeps.listJobs).not.toHaveBeenCalled();
+  });
+});
+
+describe('PATCH /jobs/:id', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  it('manager can reschedule a job', async () => {
+    const updated = makeJob({ startTime: '2026-06-02T09:00:00.000Z', endTime: '2026-06-02T11:00:00.000Z' });
+    const jobsDeps = makeJobsDeps();
+    (jobsDeps.patchJob as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'mgr@brix.local');
+
+    const res = await request(app)
+      .patch(`/jobs/${jobId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ startTime: '2026-06-02T09:00:00.000Z' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.job.startTime).toBe('2026-06-02T09:00:00.000Z');
+    expect(jobsDeps.patchJob).toHaveBeenCalledWith({
+      jobId,
+      actor: { userId: managerId, role: 'manager' },
+      patch: { startTime: '2026-06-02T09:00:00.000Z' },
+    });
+  });
+
+  it('manager reassign returns 409 when service throws conflict', async () => {
+    const jobsDeps = makeJobsDeps();
+    (jobsDeps.patchJob as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new HttpError(409, 'Technician already booked for this window'),
+    );
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'mgr@brix.local');
+
+    const res = await request(app)
+      .patch(`/jobs/${jobId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ technicianId: techBId });
+
+    expect(res.status).toBe(409);
+  });
+
+  it('technician can complete their own job', async () => {
+    const updated = makeJob({ status: 'completed' });
+    const jobsDeps = makeJobsDeps();
+    (jobsDeps.patchJob as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'techa@brix.local');
+
+    const res = await request(app)
+      .patch(`/jobs/${jobId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'completed' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.job.status).toBe('completed');
+    expect(jobsDeps.patchJob).toHaveBeenCalledWith({
+      jobId,
+      actor: { userId: techAId, role: 'technician' },
+      patch: { status: 'completed' },
+    });
+  });
+
+  it('technician cannot reschedule (only status: completed allowed)', async () => {
+    const jobsDeps = makeJobsDeps();
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'techa@brix.local');
+
+    const res = await request(app)
+      .patch(`/jobs/${jobId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ startTime: '2026-06-02T09:00:00.000Z' });
+
+    expect(res.status).toBe(403);
+    expect(jobsDeps.patchJob).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when service reports missing job', async () => {
+    const jobsDeps = makeJobsDeps();
+    (jobsDeps.patchJob as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new HttpError(404, 'Job not found'),
+    );
+    const app = createApp(await makeAuthDeps(), jobsDeps);
+    const token = await loginAs(app, 'mgr@brix.local');
+
+    const res = await request(app)
+      .patch(`/jobs/${jobId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ startTime: '2026-06-02T09:00:00.000Z' });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,0 +1,150 @@
+import { Router } from 'express';
+import type {
+  CreateJobRequest,
+  Job,
+  JobResponse,
+  JobsListResponse,
+  PatchJobRequest,
+  Role,
+} from '@brix/shared';
+import { HttpError } from '../middleware/errorHandler.js';
+import { requireAuth, requireRole } from '../middleware/auth.js';
+
+export type JobsDeps = {
+  createJob: (input: {
+    managerId: string;
+    quoteId: string;
+    technicianId: string;
+    startTime: string;
+  }) => Promise<Job>;
+  listJobs: (input: { technicianId: string }) => Promise<Job[]>;
+  patchJob: (input: {
+    jobId: string;
+    actor: { userId: string; role: Role };
+    patch: PatchJobRequest;
+  }) => Promise<Job>;
+};
+
+function isUuid(s: unknown): s is string {
+  return (
+    typeof s === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s)
+  );
+}
+
+function isIsoTimestamp(s: unknown): s is string {
+  return typeof s === 'string' && !Number.isNaN(new Date(s).getTime());
+}
+
+export function createJobsRouter(deps: JobsDeps): Router {
+  const router = Router();
+
+  router.post(
+    '/',
+    requireAuth,
+    requireRole('manager'),
+    async (req, res, next) => {
+      try {
+        const body = (req.body ?? {}) as Partial<CreateJobRequest>;
+        if (
+          !isUuid(body.quoteId) ||
+          !isUuid(body.technicianId) ||
+          !isIsoTimestamp(body.startTime)
+        ) {
+          throw new HttpError(
+            400,
+            'quoteId, technicianId and startTime are required',
+          );
+        }
+        const managerId = req.user!.userId;
+        const job = await deps.createJob({
+          managerId,
+          quoteId: body.quoteId,
+          technicianId: body.technicianId,
+          startTime: body.startTime,
+        });
+        const out: JobResponse = { job };
+        res.status(201).json(out);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  router.get('/', requireAuth, async (req, res, next) => {
+    try {
+      const technicianId = req.query.technicianId;
+      if (!isUuid(technicianId)) {
+        throw new HttpError(400, 'technicianId query param is required');
+      }
+      const actor = req.user!;
+      if (actor.role === 'technician' && actor.userId !== technicianId) {
+        throw new HttpError(403, 'Technicians can only list their own jobs');
+      }
+      const jobs = await deps.listJobs({ technicianId });
+      const out: JobsListResponse = { jobs };
+      res.status(200).json(out);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.patch('/:id', requireAuth, async (req, res, next) => {
+    try {
+      const jobId = req.params.id;
+      if (!isUuid(jobId)) {
+        throw new HttpError(400, 'invalid job id');
+      }
+      const body = (req.body ?? {}) as Partial<PatchJobRequest>;
+      const actor = req.user!;
+
+      if (actor.role === 'technician') {
+        if (
+          body.startTime !== undefined ||
+          body.technicianId !== undefined ||
+          body.status !== 'completed'
+        ) {
+          throw new HttpError(
+            403,
+            'Technicians can only mark their own job as completed',
+          );
+        }
+      } else {
+        if (body.startTime !== undefined && !isIsoTimestamp(body.startTime)) {
+          throw new HttpError(400, 'startTime must be a valid ISO timestamp');
+        }
+        if (
+          body.technicianId !== undefined &&
+          !isUuid(body.technicianId)
+        ) {
+          throw new HttpError(400, 'technicianId must be a uuid');
+        }
+        if (
+          body.startTime === undefined &&
+          body.technicianId === undefined &&
+          body.status === undefined
+        ) {
+          throw new HttpError(400, 'no fields to update');
+        }
+      }
+
+      const patch: PatchJobRequest = {};
+      if (body.startTime !== undefined) patch.startTime = body.startTime;
+      if (body.technicianId !== undefined)
+        patch.technicianId = body.technicianId;
+      if (body.status !== undefined) patch.status = body.status;
+
+      const job = await deps.patchJob({
+        jobId,
+        actor: { userId: actor.userId, role: actor.role },
+        patch,
+      });
+      const out: JobResponse = { job };
+      res.status(200).json(out);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/apps/api/src/services/jobAssignment.integration.test.ts
+++ b/apps/api/src/services/jobAssignment.integration.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { sql } from 'drizzle-orm';
+import bcrypt from 'bcryptjs';
+import { notifications, jobs, quotes, users } from '../db/schema.js';
+import { createJobAssignmentService } from './jobAssignment.js';
+import { HttpError } from '../middleware/errorHandler.js';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+describeIfDb('jobAssignment service (integration)', () => {
+  let pool: Pool;
+  let db: ReturnType<typeof drizzle>;
+  let service: ReturnType<typeof createJobAssignmentService>;
+  let managerId: string;
+  let techAId: string;
+  let techBId: string;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    db = drizzle(pool);
+    service = createJobAssignmentService(db);
+
+    const passwordHash = await bcrypt.hash('x', 4);
+    const tag = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    const u = await db
+      .insert(users)
+      .values([
+        {
+          email: `mgr-${tag}@test.local`,
+          name: 'Mgr',
+          role: 'manager',
+          passwordHash,
+        },
+        {
+          email: `tecA-${tag}@test.local`,
+          name: 'TecA',
+          role: 'technician',
+          passwordHash,
+        },
+        {
+          email: `tecB-${tag}@test.local`,
+          name: 'TecB',
+          role: 'technician',
+          passwordHash,
+        },
+      ])
+      .returning({ id: users.id, role: users.role, email: users.email });
+    managerId = u.find((r) => r.email === `mgr-${tag}@test.local`)!.id;
+    techAId = u.find((r) => r.email === `tecA-${tag}@test.local`)!.id;
+    techBId = u.find((r) => r.email === `tecB-${tag}@test.local`)!.id;
+  });
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+  });
+
+  async function freshQuote(title = 'Test'): Promise<string> {
+    const [q] = await db
+      .insert(quotes)
+      .values({ title, customerName: 'Cust', address: '1 Main St' })
+      .returning({ id: quotes.id });
+    return q.id;
+  }
+
+  async function clearJobs() {
+    await db.execute(sql`DELETE FROM notifications`);
+    await db.execute(sql`DELETE FROM jobs`);
+    await db.execute(sql`UPDATE quotes SET status = 'unscheduled'`);
+  }
+
+  beforeEach(async () => {
+    await clearJobs();
+  });
+
+  it('createJob inserts a job, notification, and flips quote to scheduled', async () => {
+    const quoteId = await freshQuote('Tap');
+    const job = await service.createJob({
+      managerId,
+      quoteId,
+      technicianId: techAId,
+      startTime: '2026-07-01T09:00:00.000Z',
+    });
+
+    expect(job.endTime).toBe('2026-07-01T11:00:00.000Z');
+    expect(job.status).toBe('scheduled');
+    expect(job.quote.status).toBe('scheduled');
+
+    const notifs = await db.execute<{ type: string; recipient_user_id: string; job_id: string }>(
+      sql`SELECT type, recipient_user_id, job_id FROM notifications WHERE job_id = ${job.id}`,
+    );
+    expect(notifs.rows).toHaveLength(1);
+    expect(notifs.rows[0].type).toBe('job_assigned');
+    expect(notifs.rows[0].recipient_user_id).toBe(techAId);
+  });
+
+  it('createJob throws 409 on sequential overlap', async () => {
+    const q1 = await freshQuote('A');
+    const q2 = await freshQuote('B');
+    await service.createJob({
+      managerId,
+      quoteId: q1,
+      technicianId: techAId,
+      startTime: '2026-07-02T09:00:00.000Z',
+    });
+
+    await expect(
+      service.createJob({
+        managerId,
+        quoteId: q2,
+        technicianId: techAId,
+        startTime: '2026-07-02T10:00:00.000Z',
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+
+  it('concurrent overlap: exactly one of two parallel inserts succeeds', async () => {
+    const q1 = await freshQuote('Concurrent A');
+    const q2 = await freshQuote('Concurrent B');
+
+    const results = await Promise.allSettled([
+      service.createJob({
+        managerId,
+        quoteId: q1,
+        technicianId: techAId,
+        startTime: '2026-07-03T09:00:00.000Z',
+      }),
+      service.createJob({
+        managerId,
+        quoteId: q2,
+        technicianId: techAId,
+        startTime: '2026-07-03T10:00:00.000Z',
+      }),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    const reason = (rejected[0] as PromiseRejectedResult).reason;
+    expect(reason).toBeInstanceOf(HttpError);
+    expect((reason as HttpError).status).toBe(409);
+  });
+
+  it('non-overlapping windows on same technician both succeed', async () => {
+    const q1 = await freshQuote('Slot 1');
+    const q2 = await freshQuote('Slot 2');
+    await service.createJob({
+      managerId,
+      quoteId: q1,
+      technicianId: techAId,
+      startTime: '2026-07-04T09:00:00.000Z',
+    });
+    await service.createJob({
+      managerId,
+      quoteId: q2,
+      technicianId: techAId,
+      startTime: '2026-07-04T11:00:00.000Z',
+    });
+  });
+
+  it('patchJob (manager reschedule) writes job_rescheduled notification', async () => {
+    const quoteId = await freshQuote('Resched');
+    const created = await service.createJob({
+      managerId,
+      quoteId,
+      technicianId: techAId,
+      startTime: '2026-07-05T09:00:00.000Z',
+    });
+
+    const updated = await service.patchJob({
+      jobId: created.id,
+      actor: { userId: managerId, role: 'manager' },
+      patch: { startTime: '2026-07-05T13:00:00.000Z' },
+    });
+    expect(updated.startTime).toBe('2026-07-05T13:00:00.000Z');
+    expect(updated.endTime).toBe('2026-07-05T15:00:00.000Z');
+
+    const notifs = await db.execute<{ type: string }>(
+      sql`SELECT type FROM notifications WHERE job_id = ${created.id} ORDER BY created_at`,
+    );
+    expect(notifs.rows.map((r) => r.type)).toEqual(['job_assigned', 'job_rescheduled']);
+  });
+
+  it('patchJob (manager reassign) re-runs conflict check and throws 409', async () => {
+    const q1 = await freshQuote('A');
+    const q2 = await freshQuote('B');
+    // Tech A has 09-11, Tech B has 09-11. Try to reassign B's job to Tech A → conflict.
+    await service.createJob({
+      managerId,
+      quoteId: q1,
+      technicianId: techAId,
+      startTime: '2026-07-06T09:00:00.000Z',
+    });
+    const techBJob = await service.createJob({
+      managerId,
+      quoteId: q2,
+      technicianId: techBId,
+      startTime: '2026-07-06T09:00:00.000Z',
+    });
+
+    await expect(
+      service.patchJob({
+        jobId: techBJob.id,
+        actor: { userId: managerId, role: 'manager' },
+        patch: { technicianId: techAId },
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('patchJob (tech complete) flips status, sets quote completed, notifies manager', async () => {
+    const quoteId = await freshQuote('Done');
+    const created = await service.createJob({
+      managerId,
+      quoteId,
+      technicianId: techAId,
+      startTime: '2026-07-07T09:00:00.000Z',
+    });
+
+    const updated = await service.patchJob({
+      jobId: created.id,
+      actor: { userId: techAId, role: 'technician' },
+      patch: { status: 'completed' },
+    });
+    expect(updated.status).toBe('completed');
+    expect(updated.quote.status).toBe('completed');
+
+    const notifs = await db.execute<{ type: string; recipient_user_id: string }>(
+      sql`SELECT type, recipient_user_id FROM notifications WHERE job_id = ${created.id} AND type = 'job_completed'`,
+    );
+    expect(notifs.rows).toHaveLength(1);
+    expect(notifs.rows[0].recipient_user_id).toBe(managerId);
+  });
+
+  it('patchJob (tech complete on someone else job) throws 403', async () => {
+    const quoteId = await freshQuote('Other');
+    const created = await service.createJob({
+      managerId,
+      quoteId,
+      technicianId: techAId,
+      startTime: '2026-07-08T09:00:00.000Z',
+    });
+
+    await expect(
+      service.patchJob({
+        jobId: created.id,
+        actor: { userId: techBId, role: 'technician' },
+        patch: { status: 'completed' },
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('patchJob on missing job throws 404', async () => {
+    await expect(
+      service.patchJob({
+        jobId: '00000000-0000-0000-0000-000000000000',
+        actor: { userId: managerId, role: 'manager' },
+        patch: { startTime: '2026-07-09T09:00:00.000Z' },
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('listJobs filters by technicianId and returns embedded quote', async () => {
+    const q1 = await freshQuote('A');
+    const q2 = await freshQuote('B');
+    await service.createJob({
+      managerId,
+      quoteId: q1,
+      technicianId: techAId,
+      startTime: '2026-07-10T09:00:00.000Z',
+    });
+    await service.createJob({
+      managerId,
+      quoteId: q2,
+      technicianId: techBId,
+      startTime: '2026-07-10T09:00:00.000Z',
+    });
+
+    const techAJobs = await service.listJobs({ technicianId: techAId });
+    expect(techAJobs).toHaveLength(1);
+    expect(techAJobs[0].technicianId).toBe(techAId);
+    expect(techAJobs[0].quote.title).toBe('A');
+  });
+});

--- a/apps/api/src/services/jobAssignment.ts
+++ b/apps/api/src/services/jobAssignment.ts
@@ -1,0 +1,360 @@
+import { eq, sql } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type {
+  Job,
+  JobStatus,
+  NotificationType,
+  QuoteSummary,
+  Role,
+} from '@brix/shared';
+import { jobs, notifications, quotes, users } from '../db/schema.js';
+import { HttpError } from '../middleware/errorHandler.js';
+
+const JOB_DURATION_HOURS = 2;
+
+export type CreateJobInput = {
+  managerId: string;
+  quoteId: string;
+  technicianId: string;
+  startTime: string;
+};
+
+export type ListJobsInput = {
+  technicianId: string;
+};
+
+export type PatchJobInput = {
+  jobId: string;
+  actor: { userId: string; role: Role };
+  patch: {
+    startTime?: string;
+    technicianId?: string;
+    status?: JobStatus;
+  };
+};
+
+export type JobAssignmentService = {
+  createJob: (input: CreateJobInput) => Promise<Job>;
+  listJobs: (input: ListJobsInput) => Promise<Job[]>;
+  patchJob: (input: PatchJobInput) => Promise<Job>;
+};
+
+type AnyDb = NodePgDatabase<Record<string, unknown>>;
+
+type JobRow = typeof jobs.$inferSelect;
+type QuoteRow = typeof quotes.$inferSelect;
+
+function addHours(iso: string, hours: number): Date {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    throw new HttpError(400, 'startTime must be a valid ISO timestamp');
+  }
+  return new Date(d.getTime() + hours * 60 * 60 * 1000);
+}
+
+function toQuoteSummary(q: QuoteRow): QuoteSummary {
+  return {
+    id: q.id,
+    title: q.title,
+    customerName: q.customerName,
+    address: q.address,
+    status: q.status,
+  };
+}
+
+function toJob(j: JobRow, q: QuoteRow): Job {
+  return {
+    id: j.id,
+    quoteId: j.quoteId,
+    technicianId: j.technicianId,
+    managerId: j.managerId,
+    startTime: j.startTime.toISOString(),
+    endTime: j.endTime.toISOString(),
+    status: j.status,
+    quote: toQuoteSummary(q),
+  };
+}
+
+function isExclusionViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: string }).code === '23P01'
+  );
+}
+
+function notificationMessage(
+  type: NotificationType,
+  startTime: Date,
+): string {
+  const when = startTime.toISOString();
+  switch (type) {
+    case 'job_assigned':
+      return `New job assigned starting ${when}`;
+    case 'job_rescheduled':
+      return `Job rescheduled to ${when}`;
+    case 'job_cancelled':
+      return `Job cancelled (was ${when})`;
+    case 'job_completed':
+      return `Job completed (was ${when})`;
+  }
+}
+
+async function assertRole(
+  tx: AnyDb,
+  userId: string,
+  expected: Role,
+  errMsg: string,
+): Promise<void> {
+  const rows = await tx
+    .select({ role: users.role })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!rows[0] || rows[0].role !== expected) {
+    throw new HttpError(400, errMsg);
+  }
+}
+
+export function createJobAssignmentService(db: AnyDb): JobAssignmentService {
+  async function findOverlap(
+    tx: AnyDb,
+    technicianId: string,
+    startTime: Date,
+    endTime: Date,
+    excludeJobId?: string,
+  ): Promise<boolean> {
+    const result = await tx.execute<{ id: string }>(sql`
+      SELECT id FROM jobs
+      WHERE technician_id = ${technicianId}
+        AND tstzrange(start_time, end_time) && tstzrange(${startTime.toISOString()}::timestamptz, ${endTime.toISOString()}::timestamptz)
+        ${excludeJobId ? sql`AND id <> ${excludeJobId}` : sql``}
+      LIMIT 1
+    `);
+    return result.rows.length > 0;
+  }
+
+  async function loadJobWithQuote(
+    tx: AnyDb,
+    jobId: string,
+  ): Promise<{ job: JobRow; quote: QuoteRow } | null> {
+    const rows = await tx
+      .select({ job: jobs, quote: quotes })
+      .from(jobs)
+      .innerJoin(quotes, eq(jobs.quoteId, quotes.id))
+      .where(eq(jobs.id, jobId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  return {
+    async createJob({ managerId, quoteId, technicianId, startTime }) {
+      const start = new Date(startTime);
+      if (Number.isNaN(start.getTime())) {
+        throw new HttpError(400, 'startTime must be a valid ISO timestamp');
+      }
+      const end = addHours(startTime, JOB_DURATION_HOURS);
+
+      try {
+        return await db.transaction(async (tx) => {
+          await assertRole(
+            tx as AnyDb,
+            technicianId,
+            'technician',
+            'technicianId does not refer to a technician',
+          );
+          await assertRole(
+            tx as AnyDb,
+            managerId,
+            'manager',
+            'managerId does not refer to a manager',
+          );
+
+          if (await findOverlap(tx as AnyDb, technicianId, start, end)) {
+            throw new HttpError(
+              409,
+              'Technician already booked for an overlapping window',
+            );
+          }
+
+          const inserted = await tx
+            .insert(jobs)
+            .values({
+              quoteId,
+              technicianId,
+              managerId,
+              startTime: start,
+              endTime: end,
+            })
+            .returning();
+          const jobRow = inserted[0];
+
+          await tx.insert(notifications).values({
+            recipientUserId: technicianId,
+            jobId: jobRow.id,
+            type: 'job_assigned',
+            message: notificationMessage('job_assigned', start),
+          });
+
+          const updatedQuote = await tx
+            .update(quotes)
+            .set({ status: 'scheduled', updatedAt: new Date() })
+            .where(eq(quotes.id, quoteId))
+            .returning();
+
+          return toJob(jobRow, updatedQuote[0]);
+        });
+      } catch (err) {
+        if (isExclusionViolation(err)) {
+          throw new HttpError(
+            409,
+            'Technician already booked for an overlapping window',
+          );
+        }
+        throw err;
+      }
+    },
+
+    async listJobs({ technicianId }) {
+      const rows = await db
+        .select({ job: jobs, quote: quotes })
+        .from(jobs)
+        .innerJoin(quotes, eq(jobs.quoteId, quotes.id))
+        .where(eq(jobs.technicianId, technicianId))
+        .orderBy(jobs.startTime);
+      return rows.map((r) => toJob(r.job, r.quote));
+    },
+
+    async patchJob({ jobId, actor, patch }) {
+      try {
+        return await db.transaction(async (tx) => {
+          const current = await loadJobWithQuote(tx as AnyDb, jobId);
+          if (!current) {
+            throw new HttpError(404, 'Job not found');
+          }
+          const { job, quote } = current;
+
+          if (actor.role === 'technician') {
+            if (job.technicianId !== actor.userId) {
+              throw new HttpError(403, 'Forbidden');
+            }
+            if (
+              patch.startTime !== undefined ||
+              patch.technicianId !== undefined
+            ) {
+              throw new HttpError(
+                403,
+                'Technicians can only update job status to completed',
+              );
+            }
+            if (patch.status !== 'completed') {
+              throw new HttpError(
+                400,
+                'Technicians can only set status to completed',
+              );
+            }
+
+            const updated = await tx
+              .update(jobs)
+              .set({ status: 'completed', updatedAt: new Date() })
+              .where(eq(jobs.id, jobId))
+              .returning();
+            const updatedQuote = await tx
+              .update(quotes)
+              .set({ status: 'completed', updatedAt: new Date() })
+              .where(eq(quotes.id, job.quoteId))
+              .returning();
+
+            await tx.insert(notifications).values({
+              recipientUserId: job.managerId,
+              jobId: job.id,
+              type: 'job_completed',
+              message: notificationMessage('job_completed', job.startTime),
+            });
+
+            return toJob(updated[0], updatedQuote[0]);
+          }
+
+          // manager path
+          const newTechnicianId = patch.technicianId ?? job.technicianId;
+          const newStartTime = patch.startTime
+            ? new Date(patch.startTime)
+            : job.startTime;
+          const newEndTime = patch.startTime
+            ? addHours(patch.startTime, JOB_DURATION_HOURS)
+            : job.endTime;
+
+          if (patch.technicianId !== undefined) {
+            await assertRole(
+              tx as AnyDb,
+              patch.technicianId,
+              'technician',
+              'technicianId does not refer to a technician',
+            );
+          }
+
+          const rescheduling =
+            patch.startTime !== undefined || patch.technicianId !== undefined;
+
+          if (rescheduling) {
+            if (
+              await findOverlap(
+                tx as AnyDb,
+                newTechnicianId,
+                newStartTime,
+                newEndTime,
+                job.id,
+              )
+            ) {
+              throw new HttpError(
+                409,
+                'Technician already booked for an overlapping window',
+              );
+            }
+          }
+
+          const updateValues: Partial<typeof jobs.$inferInsert> = {
+            updatedAt: new Date(),
+          };
+          if (patch.startTime !== undefined) {
+            updateValues.startTime = newStartTime;
+            updateValues.endTime = newEndTime;
+          }
+          if (patch.technicianId !== undefined) {
+            updateValues.technicianId = patch.technicianId;
+          }
+          if (patch.status !== undefined) {
+            updateValues.status = patch.status;
+          }
+
+          const updated = await tx
+            .update(jobs)
+            .set(updateValues)
+            .where(eq(jobs.id, jobId))
+            .returning();
+
+          if (rescheduling) {
+            await tx.insert(notifications).values({
+              recipientUserId: newTechnicianId,
+              jobId: job.id,
+              type: 'job_rescheduled',
+              message: notificationMessage('job_rescheduled', newStartTime),
+            });
+          }
+
+          return toJob(updated[0], quote);
+        });
+      } catch (err) {
+        if (isExclusionViolation(err)) {
+          throw new HttpError(
+            409,
+            'Technician already booked for an overlapping window',
+          );
+        }
+        throw err;
+      }
+    },
+  };
+}
+

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -44,3 +44,50 @@ export type LoginResponse = {
 export type ErrorResponse = {
   error: string;
 };
+
+export type JobStatus = 'scheduled' | 'in_progress' | 'completed' | 'cancelled';
+
+export type NotificationType =
+  | 'job_assigned'
+  | 'job_rescheduled'
+  | 'job_cancelled'
+  | 'job_completed';
+
+export type QuoteSummary = {
+  id: string;
+  title: string;
+  customerName: string;
+  address: string;
+  status: QuoteStatus;
+};
+
+export type Job = {
+  id: string;
+  quoteId: string;
+  technicianId: string;
+  managerId: string;
+  startTime: string;
+  endTime: string;
+  status: JobStatus;
+  quote: QuoteSummary;
+};
+
+export type CreateJobRequest = {
+  quoteId: string;
+  technicianId: string;
+  startTime: string;
+};
+
+export type PatchJobRequest = {
+  startTime?: string;
+  technicianId?: string;
+  status?: JobStatus;
+};
+
+export type JobsListResponse = {
+  jobs: Job[];
+};
+
+export type JobResponse = {
+  job: Job;
+};


### PR DESCRIPTION
Closes #6
Linear: https://linear.app/chuck-heya/issue/PER-7/jobs-api-with-conflict-postgetpatch-jobs-with-overlap-prevention

## Summary
Adds the core scheduling endpoints — `POST /jobs` (manager-only), `GET /jobs?technicianId=X` (manager any / technician self), and `PATCH /jobs/:id` (manager reschedule/reassign or technician self-complete). The jobAssignment service runs each mutation inside a Drizzle transaction, performs an app-level `tstzrange && tstzrange` overlap check before insert, inserts the job + a notification row, flips the quote status, and translates Postgres `23P01` exclusion violations into HTTP 409. Notifications use a new `job_completed` enum value added via migration 0002.

## Tests
- Added: `apps/api/src/routes/jobs.test.ts` — 13 unit tests covering POST/GET/PATCH role enforcement, body validation, and 409/404 propagation.
- Added: `apps/api/src/services/jobAssignment.integration.test.ts` — 10 DB-gated integration tests including happy path, sequential overlap, **concurrent overlap (Promise.all → exactly one succeeds)**, manager reschedule notification, manager reassign conflict, technician complete, technician unauthorized, missing job, and listJobs filter.
- Status: 47/47 passing across the API workspace; typecheck clean (`tsc --noEmit`).

## Files touched
- `apps/api/src/services/jobAssignment.ts` — new transactional service.
- `apps/api/src/routes/jobs.ts` — new Express router with role gates.
- `apps/api/src/app.ts` — accepts optional `JobsDeps`, mounts `/jobs`.
- `apps/api/src/index.ts` — wires DB-backed jobAssignment service.
- `apps/api/src/db/schema.ts` + `schema.test.ts` — adds `job_completed` notification type.
- `apps/api/src/db/migrations/0002_notification_completed.sql` (+ snapshot/journal) — enum migration.
- `packages/shared/src/index.ts` — adds `Job`, `JobStatus`, `NotificationType`, `QuoteSummary`, `CreateJobRequest`, `PatchJobRequest`, `JobsListResponse`, `JobResponse`.

## Follow-ups
- Wire `GET /notifications` for the polling client (separate Linear issue).
- Optional: add cancel/delete job endpoint when product asks for it.