### PR TITLE
[PER-8] notifications-api: inbox list + mark-as-read

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,10 @@ import { createAuthRouter } from './routes/auth.js';
 import { quotesRouter } from './routes/quotes.js';
 import { usersRouter } from './routes/users.js';
 import { createJobsRouter, type JobsDeps } from './routes/jobs.js';
+import {
+  createNotificationsRouter,
+  type NotificationsDeps,
+} from './routes/notifications.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 export type UserRecord = {
@@ -19,9 +23,13 @@ export type AuthDeps = {
   findUserById: (id: string) => Promise<UserRecord | null>;
 };
 
-export type { JobsDeps };
+export type { JobsDeps, NotificationsDeps };
 
-export function createApp(deps?: AuthDeps, jobsDeps?: JobsDeps): Express {
+export function createApp(
+  deps?: AuthDeps,
+  jobsDeps?: JobsDeps,
+  notificationsDeps?: NotificationsDeps,
+): Express {
   const app = express();
   app.use(express.json());
 
@@ -39,6 +47,10 @@ export function createApp(deps?: AuthDeps, jobsDeps?: JobsDeps): Express {
 
   if (jobsDeps) {
     app.use('/jobs', createJobsRouter(jobsDeps));
+  }
+
+  if (notificationsDeps) {
+    app.use('/notifications', createNotificationsRouter(notificationsDeps));
   }
 
   app.use(errorHandler);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,10 +1,12 @@
 import './db/env.js';
-import { eq } from 'drizzle-orm';
+import { and, desc, eq, isNull, sql } from 'drizzle-orm';
 import { createApp } from './app.js';
-import type { AuthDeps, UserRecord } from './app.js';
+import type { AuthDeps, NotificationsDeps, UserRecord } from './app.js';
 import { db } from './db/client.js';
-import { users } from './db/schema.js';
+import { notifications, users } from './db/schema.js';
 import { createJobAssignmentService } from './services/jobAssignment.js';
+import { HttpError } from './middleware/errorHandler.js';
+import type { Notification } from '@brix/shared';
 
 const port = Number(process.env.PORT) || 3001;
 
@@ -38,7 +40,62 @@ function toUserRecord(row: typeof users.$inferSelect): UserRecord {
 }
 
 const jobsService = createJobAssignmentService(db);
-const app = createApp(deps, jobsService);
+
+type NotificationRow = typeof notifications.$inferSelect;
+
+function toNotification(row: NotificationRow): Notification {
+  return {
+    id: row.id,
+    recipientUserId: row.recipientUserId,
+    jobId: row.jobId,
+    type: row.type,
+    message: row.message,
+    readAt: row.readAt ? row.readAt.toISOString() : null,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+const notificationsDeps: NotificationsDeps = {
+  async listNotifications({ recipientUserId }) {
+    const rows = await db
+      .select()
+      .from(notifications)
+      .where(eq(notifications.recipientUserId, recipientUserId))
+      .orderBy(desc(notifications.createdAt));
+    const unreadRows = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(notifications)
+      .where(
+        and(
+          eq(notifications.recipientUserId, recipientUserId),
+          isNull(notifications.readAt),
+        ),
+      );
+    const unreadCount = unreadRows[0]?.count ?? 0;
+    return {
+      notifications: rows.map(toNotification),
+      unreadCount,
+    };
+  },
+  async markRead({ notificationId, recipientUserId }) {
+    const updated = await db
+      .update(notifications)
+      .set({ readAt: new Date() })
+      .where(
+        and(
+          eq(notifications.id, notificationId),
+          eq(notifications.recipientUserId, recipientUserId),
+        ),
+      )
+      .returning();
+    if (!updated[0]) {
+      throw new HttpError(404, 'Notification not found');
+    }
+    return toNotification(updated[0]);
+  },
+};
+
+const app = createApp(deps, jobsService, notificationsDeps);
 
 app.listen(port, () => {
   console.log(`api listening on http://localhost:${port}`);

--- a/apps/api/src/routes/notifications.test.ts
+++ b/apps/api/src/routes/notifications.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import bcrypt from 'bcryptjs';
+
+vi.stubEnv('DATABASE_URL', 'postgresql://fake');
+vi.mock('../db/client.js', () => ({ db: { select: vi.fn() } }));
+
+const { createApp } = await import('../app.js');
+import type { AuthDeps, UserRecord, NotificationsDeps } from '../app.js';
+import type { LoginResponse, Notification } from '@brix/shared';
+import { HttpError } from '../middleware/errorHandler.js';
+
+const password = 'password123';
+
+const bobId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const aliceId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const jobId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+const notif1Id = '11111111-aaaa-aaaa-aaaa-111111111111';
+const notif2Id = '22222222-aaaa-aaaa-aaaa-222222222222';
+const otherNotifId = '33333333-aaaa-aaaa-aaaa-333333333333';
+
+async function makeAuthDeps(): Promise<AuthDeps> {
+  const passwordHash = await bcrypt.hash(password, 4);
+  const bob: UserRecord = {
+    id: bobId,
+    email: 'bob@brix.local',
+    name: 'Bob',
+    role: 'technician',
+    passwordHash,
+  };
+  const alice: UserRecord = {
+    id: aliceId,
+    email: 'alice@brix.local',
+    name: 'Alice',
+    role: 'technician',
+    passwordHash,
+  };
+  const byEmail = new Map([
+    [bob.email, bob],
+    [alice.email, alice],
+  ]);
+  const byId = new Map([
+    [bob.id, bob],
+    [alice.id, alice],
+  ]);
+  return {
+    findUserByEmail: async (email) => byEmail.get(email) ?? null,
+    findUserById: async (id) => byId.get(id) ?? null,
+  };
+}
+
+function makeNotif(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: notif1Id,
+    recipientUserId: bobId,
+    jobId,
+    type: 'job_assigned',
+    message: 'New job assigned starting 2026-06-01T09:00:00.000Z',
+    readAt: null,
+    createdAt: '2026-05-01T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeNotificationsDeps(): NotificationsDeps {
+  return {
+    listNotifications: vi.fn(),
+    markRead: vi.fn(),
+  };
+}
+
+async function loginAs(app: ReturnType<typeof createApp>, email: string) {
+  const res = await request(app)
+    .post('/auth/login')
+    .send({ email, password });
+  return (res.body as LoginResponse).token;
+}
+
+describe('GET /notifications', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  it('returns 401 without a token', async () => {
+    const app = createApp(await makeAuthDeps(), undefined, makeNotificationsDeps());
+    const res = await request(app).get('/notifications');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns own notifications sorted desc with unreadCount', async () => {
+    const newer = makeNotif({ id: notif2Id, createdAt: '2026-05-01T11:00:00.000Z' });
+    const older = makeNotif({ id: notif1Id, createdAt: '2026-05-01T10:00:00.000Z', readAt: '2026-05-01T10:30:00.000Z' });
+    const deps = makeNotificationsDeps();
+    (deps.listNotifications as ReturnType<typeof vi.fn>).mockResolvedValue({
+      notifications: [newer, older],
+      unreadCount: 1,
+    });
+
+    const app = createApp(await makeAuthDeps(), undefined, deps);
+    const token = await loginAs(app, 'bob@brix.local');
+
+    const res = await request(app)
+      .get('/notifications')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.unreadCount).toBe(1);
+    expect(res.body.notifications).toHaveLength(2);
+    expect(res.body.notifications[0].id).toBe(notif2Id);
+    expect(deps.listNotifications).toHaveBeenCalledWith({ recipientUserId: bobId });
+  });
+});
+
+describe('POST /notifications/:id/read', () => {
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  it('returns 401 without a token', async () => {
+    const app = createApp(await makeAuthDeps(), undefined, makeNotificationsDeps());
+    const res = await request(app).post(`/notifications/${notif1Id}/read`);
+    expect(res.status).toBe(401);
+  });
+
+  it('marks own notification as read', async () => {
+    const updated = makeNotif({ readAt: '2026-05-01T12:00:00.000Z' });
+    const deps = makeNotificationsDeps();
+    (deps.markRead as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+
+    const app = createApp(await makeAuthDeps(), undefined, deps);
+    const token = await loginAs(app, 'bob@brix.local');
+
+    const res = await request(app)
+      .post(`/notifications/${notif1Id}/read`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.notification.readAt).toBe('2026-05-01T12:00:00.000Z');
+    expect(deps.markRead).toHaveBeenCalledWith({
+      notificationId: notif1Id,
+      recipientUserId: bobId,
+    });
+  });
+
+  it('returns 404 when notification belongs to another user', async () => {
+    const deps = makeNotificationsDeps();
+    (deps.markRead as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new HttpError(404, 'Notification not found'),
+    );
+    const app = createApp(await makeAuthDeps(), undefined, deps);
+    const token = await loginAs(app, 'bob@brix.local');
+
+    const res = await request(app)
+      .post(`/notifications/${otherNotifId}/read`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 on invalid uuid', async () => {
+    const app = createApp(await makeAuthDeps(), undefined, makeNotificationsDeps());
+    const token = await loginAs(app, 'bob@brix.local');
+    const res = await request(app)
+      .post('/notifications/not-a-uuid/read')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,0 +1,63 @@
+import { Router } from 'express';
+import type {
+  Notification,
+  NotificationResponse,
+  NotificationsListResponse,
+} from '@brix/shared';
+import { HttpError } from '../middleware/errorHandler.js';
+import { requireAuth } from '../middleware/auth.js';
+
+export type NotificationsDeps = {
+  listNotifications: (input: {
+    recipientUserId: string;
+  }) => Promise<{ notifications: Notification[]; unreadCount: number }>;
+  markRead: (input: {
+    notificationId: string;
+    recipientUserId: string;
+  }) => Promise<Notification>;
+};
+
+function isUuid(s: unknown): s is string {
+  return (
+    typeof s === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s)
+  );
+}
+
+export function createNotificationsRouter(deps: NotificationsDeps): Router {
+  const router = Router();
+
+  router.get('/', requireAuth, async (req, res, next) => {
+    try {
+      const recipientUserId = req.user!.userId;
+      const result = await deps.listNotifications({ recipientUserId });
+      const out: NotificationsListResponse = {
+        notifications: result.notifications,
+        unreadCount: result.unreadCount,
+      };
+      res.status(200).json(out);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/:id/read', requireAuth, async (req, res, next) => {
+    try {
+      const notificationId = req.params.id;
+      if (!isUuid(notificationId)) {
+        throw new HttpError(400, 'invalid notification id');
+      }
+      const recipientUserId = req.user!.userId;
+      const notification = await deps.markRead({
+        notificationId,
+        recipientUserId,
+      });
+      const out: NotificationResponse = { notification };
+      res.status(200).json(out);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -91,3 +91,22 @@ export type JobsListResponse = {
 export type JobResponse = {
   job: Job;
 };
+
+export type Notification = {
+  id: string;
+  recipientUserId: string;
+  jobId: string;
+  type: NotificationType;
+  message: string;
+  readAt: string | null;
+  createdAt: string;
+};
+
+export type NotificationsListResponse = {
+  notifications: Notification[];
+  unreadCount: number;
+};
+
+export type NotificationResponse = {
+  notification: Notification;
+};


### PR DESCRIPTION
Closes #7
Linear: https://linear.app/chuck-heya/issue/PER-8/notifications-api-inbox-list-mark-as-read

## Summary
Adds the notifications inbox API: `GET /notifications` returns the caller's notifications sorted `created_at desc` with an `unreadCount` envelope, and `POST /notifications/:id/read` flips `read_at = now()` for the caller's own notification (404 otherwise). Routes are wired through an injectable `NotificationsDeps` so they unit-test cleanly without the DB; `index.ts` provides the real Drizzle-backed implementation.

## Tests
- Added: `apps/api/src/routes/notifications.test.ts` — 6 cases: 401 without token (GET + POST), sorted desc list with unreadCount, mark own as read, 404 for another user's notification, 400 on invalid uuid.
- Status: 50 passing / 50 total (11 DB integration tests skipped as expected without a live Postgres).

## Files touched
- `apps/api/src/routes/notifications.ts` — new router with GET/POST handlers.
- `apps/api/src/routes/notifications.test.ts` — supertest cases against an injected `NotificationsDeps`.
- `apps/api/src/app.ts` — wires `createNotificationsRouter` when deps are passed.
- `apps/api/src/index.ts` — Drizzle-backed `listNotifications` (with COUNT for unread) and `markRead`.
- `packages/shared/src/index.ts` — exports `Notification`, `NotificationsListResponse`, `NotificationResponse`.

## Follow-ups
- Bulk mark-all-read, filtering, and websocket push are intentionally out of scope per the issue.