### PR TITLE
[PER-13] web-notifications-inbox: bell, dropdown, polling

### DIFF
--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { homePathForRole, useAuth } from '../lib/auth';
+import { NotificationBell } from './NotificationBell';
 
 export function Layout({ children }: { children: ReactNode }) {
   const { user, logout } = useAuth();
@@ -46,6 +47,7 @@ export function Layout({ children }: { children: ReactNode }) {
                 Inbox
               </NavLink>
               <span className="mx-2 h-5 w-px bg-border-subtle" />
+              <NotificationBell />
               <span className="text-xs text-ink-subtle">
                 {user.email} · <span className="uppercase tracking-wider">{user.role}</span>
               </span>

--- a/apps/web/src/components/NotificationBell.test.tsx
+++ b/apps/web/src/components/NotificationBell.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { NotificationBell } from './NotificationBell';
+import { AuthProvider, AUTH_STORAGE_KEY } from '../lib/auth';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeNotification(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'n1',
+    recipientUserId: 'u1',
+    jobId: 'j1',
+    type: 'job_assigned' as const,
+    message: 'New job assigned: HVAC',
+    readAt: null,
+    createdAt: '2026-05-01T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function withAuth(ui: React.ReactNode) {
+  window.localStorage.setItem(
+    AUTH_STORAGE_KEY,
+    JSON.stringify({
+      token: 't',
+      user: { id: 'u1', email: 'm@x.io', role: 'manager' },
+    }),
+  );
+  return (
+    <MemoryRouter>
+      <AuthProvider>{ui}</AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('<NotificationBell />', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('hides badge when unreadCount is 0', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse({ notifications: [], unreadCount: 0 }),
+    );
+    render(withAuth(<NotificationBell />));
+
+    await waitFor(() =>
+      expect(globalThis.fetch).toHaveBeenCalled(),
+    );
+    expect(screen.queryByTestId('notification-badge')).toBeNull();
+  });
+
+  it('shows badge with unread count and reveals dropdown on click', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse({
+        notifications: [makeNotification()],
+        unreadCount: 1,
+      }),
+    );
+    render(withAuth(<NotificationBell />));
+
+    const badge = await screen.findByTestId('notification-badge');
+    expect(badge).toHaveTextContent('1');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /notifications/i }));
+    const dialog = await screen.findByRole('dialog', { name: /notifications/i });
+    expect(within(dialog).getByText(/HVAC/)).toBeInTheDocument();
+  });
+
+  it('clicking an unread notification calls mark-as-read', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    const initial = makeNotification({ id: 'n-click' });
+    fetchMock.mockImplementation((url, init) => {
+      if (
+        String(url).includes('/notifications/n-click/read') &&
+        (init as RequestInit | undefined)?.method === 'POST'
+      ) {
+        return Promise.resolve(
+          jsonResponse({
+            notification: { ...initial, readAt: '2026-05-01T09:01:00.000Z' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse({ notifications: [initial], unreadCount: 1 }),
+      );
+    });
+
+    render(withAuth(<NotificationBell />));
+    const user = userEvent.setup();
+    await user.click(
+      await screen.findByRole('button', { name: /notifications/i }),
+    );
+    const dialog = await screen.findByRole('dialog', { name: /notifications/i });
+    await user.click(within(dialog).getByText(/HVAC/));
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          String(url).includes('/notifications/n-click/read') &&
+          (init as RequestInit | undefined)?.method === 'POST',
+      );
+      expect(post).toBeDefined();
+    });
+  });
+
+  it('renders nothing when unauthenticated', () => {
+    window.localStorage.clear();
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <NotificationBell />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('button', { name: /notifications/i })).toBeNull();
+  });
+});

--- a/apps/web/src/components/NotificationBell.tsx
+++ b/apps/web/src/components/NotificationBell.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useNotifications } from '../lib/useNotifications';
+import { useAuth } from '../lib/auth';
+import { NotificationItem } from './NotificationItem';
+
+const MAX_VISIBLE = 20;
+
+export function NotificationBell() {
+  const { isAuthenticated } = useAuth();
+  const { notifications, unreadCount, loading, error, markRead, markAllRead } =
+    useNotifications({ enabled: isAuthenticated });
+  const [open, setOpen] = useState(false);
+  const [now, setNow] = useState(() => new Date());
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setNow(new Date());
+    const onClick = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  if (!isAuthenticated) return null;
+
+  const visible = notifications.slice(0, MAX_VISIBLE);
+  const hasUnread = unreadCount > 0;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="relative inline-flex h-9 w-9 items-center justify-center rounded-md text-ink-muted hover:text-ink hover:bg-bg-elevated transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-purple-400"
+        aria-label={
+          hasUnread
+            ? `Notifications, ${unreadCount} unread`
+            : 'Notifications'
+        }
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        <BellIcon />
+        {hasUnread ? (
+          <span
+            data-testid="notification-badge"
+            className="absolute -top-0.5 -right-0.5 inline-flex min-w-[18px] h-[18px] items-center justify-center rounded-full bg-accent-purple-500 text-[10px] font-semibold text-white px-1 shadow-glow"
+          >
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        ) : null}
+      </button>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="Notifications"
+          className="absolute right-0 mt-2 w-[22rem] max-w-[calc(100vw-2rem)] origin-top-right card overflow-hidden z-20"
+        >
+          <header className="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
+            <span className="text-sm font-semibold text-ink">Notifications</span>
+            <span className="text-2xs uppercase tracking-wider text-ink-subtle">
+              {hasUnread ? `${unreadCount} unread` : 'all caught up'}
+            </span>
+          </header>
+
+          <div className="max-h-96 overflow-y-auto">
+            {loading && visible.length === 0 ? (
+              <p className="px-4 py-6 text-sm text-ink-muted">Loading…</p>
+            ) : error ? (
+              <p className="px-4 py-6 text-sm text-ink-muted">
+                Couldn't load notifications.
+              </p>
+            ) : visible.length === 0 ? (
+              <p className="px-4 py-6 text-sm text-ink-muted">
+                No notifications yet.
+              </p>
+            ) : (
+              visible.map((n) => (
+                <NotificationItem
+                  key={n.id}
+                  notification={n}
+                  now={now}
+                  onClick={(id) => {
+                    if (!n.readAt) void markRead(id);
+                  }}
+                />
+              ))
+            )}
+          </div>
+
+          <footer className="flex items-center justify-between px-4 py-2 border-t border-border-subtle bg-bg-canvas/40">
+            <Link
+              to="/inbox"
+              onClick={() => setOpen(false)}
+              className="text-xs text-accent-purple-300 hover:text-accent-purple-200"
+            >
+              View all
+            </Link>
+            <button
+              type="button"
+              onClick={() => void markAllRead()}
+              disabled={!hasUnread}
+              className="text-xs text-ink-muted hover:text-ink disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Mark all read
+            </button>
+          </footer>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-5 w-5"
+      aria-hidden
+    >
+      <path d="M6 8a6 6 0 1 1 12 0c0 3.5 1 5 2 6H4c1-1 2-2.5 2-6Z" />
+      <path d="M10 18a2 2 0 0 0 4 0" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/NotificationItem.tsx
+++ b/apps/web/src/components/NotificationItem.tsx
@@ -1,0 +1,87 @@
+import type { Notification, NotificationType } from '@brix/shared';
+
+const TYPE_META: Record<NotificationType, { glyph: string; label: string }> = {
+  job_assigned: { glyph: '◆', label: 'Assigned' },
+  job_rescheduled: { glyph: '↻', label: 'Rescheduled' },
+  job_cancelled: { glyph: '✕', label: 'Cancelled' },
+  job_completed: { glyph: '✓', label: 'Completed' },
+};
+
+function relativeTime(iso: string, now: Date): string {
+  const then = new Date(iso).getTime();
+  const diffMs = now.getTime() - then;
+  const sec = Math.round(diffMs / 1000);
+  if (sec < 60) return 'just now';
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export type NotificationItemProps = {
+  notification: Notification;
+  now: Date;
+  onClick: (id: string) => void;
+};
+
+export function NotificationItem({
+  notification,
+  now,
+  onClick,
+}: NotificationItemProps) {
+  const meta = TYPE_META[notification.type];
+  const isRead = Boolean(notification.readAt);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(notification.id)}
+      className={`w-full text-left px-4 py-3 flex gap-3 items-start border-b border-border-subtle/60 last:border-b-0 transition ${
+        isRead
+          ? 'opacity-60 hover:bg-bg-elevated/40'
+          : 'bg-accent-purple-500/[0.04] hover:bg-accent-purple-500/[0.08]'
+      }`}
+      aria-label={`${meta.label}: ${notification.message}`}
+    >
+      <span
+        className={`mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-sm font-semibold ${
+          isRead
+            ? 'bg-bg-elevated text-ink-subtle'
+            : 'bg-accent-purple-600/20 text-accent-purple-300'
+        }`}
+        aria-hidden
+      >
+        {meta.glyph}
+      </span>
+      <span className="flex-1 min-w-0">
+        <span className="flex items-center justify-between gap-2">
+          <span className="text-2xs uppercase tracking-wider text-ink-subtle">
+            {meta.label}
+          </span>
+          <span className="text-2xs text-ink-subtle">
+            {relativeTime(notification.createdAt, now)}
+          </span>
+        </span>
+        <span
+          className={`block text-sm mt-0.5 ${
+            isRead ? 'text-ink-muted' : 'text-ink'
+          }`}
+        >
+          {notification.message}
+        </span>
+      </span>
+      {isRead ? null : (
+        <span
+          className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-accent-purple-400 shadow-glow"
+          aria-hidden
+        />
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/lib/useNotifications.test.ts
+++ b/apps/web/src/lib/useNotifications.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useNotifications, POLL_INTERVAL_MS } from './useNotifications';
+import { apiClient } from './api';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeNotification(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'n1',
+    recipientUserId: 'u1',
+    jobId: 'j1',
+    type: 'job_assigned' as const,
+    message: 'Job assigned: HVAC',
+    readAt: null,
+    createdAt: '2026-05-01T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+    apiClient.setToken('test-token');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    apiClient.setToken(null);
+    vi.useRealTimers();
+  });
+
+  it('fetches /notifications on mount and exposes data + unreadCount', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        notifications: [makeNotification()],
+        unreadCount: 1,
+      }),
+    );
+
+    const { result } = renderHook(() => useNotifications({ enabled: true }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.unreadCount).toBe(1);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/notifications');
+  });
+
+  it('does not fetch when disabled (no auth token)', () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    const { result } = renderHook(() => useNotifications({ enabled: false }));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.notifications).toEqual([]);
+    expect(result.current.unreadCount).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('polls every POLL_INTERVAL_MS while mounted', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(jsonResponse({ notifications: [], unreadCount: 0 })),
+    );
+
+    const { unmount } = renderHook(() => useNotifications({ enabled: true }));
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 2);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('markRead posts to /notifications/:id/read and updates state optimistically', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    const initial = makeNotification({ id: 'n-unread', readAt: null });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ notifications: [initial], unreadCount: 1 }),
+    );
+
+    const { result } = renderHook(() => useNotifications({ enabled: true }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        notification: { ...initial, readAt: '2026-05-01T09:05:00.000Z' },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.markRead('n-unread');
+    });
+
+    const calls = fetchMock.mock.calls;
+    const postCall = calls.find(
+      ([url, init]) =>
+        String(url).includes('/notifications/n-unread/read') &&
+        (init as RequestInit | undefined)?.method === 'POST',
+    );
+    expect(postCall).toBeDefined();
+    expect(result.current.unreadCount).toBe(0);
+    expect(result.current.notifications[0]!.readAt).toBe(
+      '2026-05-01T09:05:00.000Z',
+    );
+  });
+
+  it('markAllRead fires a POST per unread notification only', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    const a = makeNotification({ id: 'a', readAt: null });
+    const b = makeNotification({
+      id: 'b',
+      readAt: '2026-05-01T09:00:00.000Z',
+    });
+    const c = makeNotification({ id: 'c', readAt: null });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ notifications: [a, b, c], unreadCount: 2 }),
+    );
+
+    const { result } = renderHook(() => useNotifications({ enabled: true }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    fetchMock.mockImplementation((url) =>
+      Promise.resolve(
+        jsonResponse({
+          notification: {
+            ...makeNotification({
+              id: String(url).split('/notifications/')[1]!.split('/')[0],
+              readAt: '2026-05-01T09:10:00.000Z',
+            }),
+          },
+        }),
+      ),
+    );
+
+    await act(async () => {
+      await result.current.markAllRead();
+    });
+
+    const postPaths = fetchMock.mock.calls
+      .filter(([, init]) => (init as RequestInit | undefined)?.method === 'POST')
+      .map(([url]) => String(url));
+    expect(postPaths.some((p) => p.includes('/notifications/a/read'))).toBe(true);
+    expect(postPaths.some((p) => p.includes('/notifications/c/read'))).toBe(true);
+    expect(postPaths.some((p) => p.includes('/notifications/b/read'))).toBe(false);
+    expect(result.current.unreadCount).toBe(0);
+  });
+});

--- a/apps/web/src/lib/useNotifications.ts
+++ b/apps/web/src/lib/useNotifications.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  Notification,
+  NotificationResponse,
+  NotificationsListResponse,
+} from '@brix/shared';
+import { apiClient } from './api';
+
+export const POLL_INTERVAL_MS = 10_000;
+
+export type UseNotificationsOptions = {
+  enabled: boolean;
+  intervalMs?: number;
+};
+
+export type UseNotificationsResult = {
+  notifications: Notification[];
+  unreadCount: number;
+  loading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+  markRead: (id: string) => Promise<void>;
+  markAllRead: () => Promise<void>;
+};
+
+function deriveUnread(list: Notification[]): number {
+  return list.reduce((acc, n) => (n.readAt ? acc : acc + 1), 0);
+}
+
+export function useNotifications(
+  options: UseNotificationsOptions,
+): UseNotificationsResult {
+  const { enabled, intervalMs = POLL_INTERVAL_MS } = options;
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<Error | null>(null);
+  const cancelledRef = useRef(false);
+
+  const fetchOnce = useCallback(async () => {
+    try {
+      const res = await apiClient.get<NotificationsListResponse>('/notifications');
+      if (cancelledRef.current) return;
+      setNotifications(res.notifications);
+      setUnreadCount(res.unreadCount);
+      setError(null);
+    } catch (err) {
+      if (cancelledRef.current) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (!cancelledRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    if (!enabled) {
+      setNotifications([]);
+      setUnreadCount(0);
+      setLoading(false);
+      setError(null);
+      return () => {
+        cancelledRef.current = true;
+      };
+    }
+    setLoading(true);
+    void fetchOnce();
+    const id = setInterval(() => {
+      void fetchOnce();
+    }, intervalMs);
+    return () => {
+      cancelledRef.current = true;
+      clearInterval(id);
+    };
+  }, [enabled, intervalMs, fetchOnce]);
+
+  const markRead = useCallback(async (id: string) => {
+    const res = await apiClient.post<NotificationResponse>(
+      `/notifications/${id}/read`,
+    );
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? res.notification : n)),
+    );
+    setUnreadCount((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const markAllRead = useCallback(async () => {
+    const unread = notifications.filter((n) => !n.readAt);
+    if (unread.length === 0) return;
+    const results = await Promise.allSettled(
+      unread.map((n) =>
+        apiClient.post<NotificationResponse>(`/notifications/${n.id}/read`),
+      ),
+    );
+    setNotifications((prev) => {
+      const next = prev.map((n) => ({ ...n }));
+      results.forEach((r, i) => {
+        if (r.status === 'fulfilled') {
+          const target = unread[i]!;
+          const updated = next.find((x) => x.id === target.id);
+          if (updated) updated.readAt = r.value.notification.readAt;
+        }
+      });
+      return next;
+    });
+    setUnreadCount((prev) =>
+      Math.max(0, prev - results.filter((r) => r.status === 'fulfilled').length),
+    );
+  }, [notifications]);
+
+  return {
+    notifications,
+    unreadCount,
+    loading,
+    error,
+    refresh: fetchOnce,
+    markRead,
+    markAllRead,
+  };
+}

--- a/apps/web/src/routes/Inbox.tsx
+++ b/apps/web/src/routes/Inbox.tsx
@@ -1,17 +1,63 @@
+import { useEffect, useState } from 'react';
 import { Layout } from '../components/Layout';
+import { NotificationItem } from '../components/NotificationItem';
+import { useAuth } from '../lib/auth';
+import { useNotifications } from '../lib/useNotifications';
 
 export function Inbox() {
+  const { isAuthenticated } = useAuth();
+  const { notifications, unreadCount, loading, error, markRead, markAllRead } =
+    useNotifications({ enabled: isAuthenticated });
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
   return (
     <Layout>
-      <header className="mb-6">
-        <p className="text-xs uppercase tracking-widest text-accent-purple-400">Inbox</p>
-        <h1 className="text-3xl font-semibold text-ink">Notifications</h1>
-        <p className="text-sm text-ink-muted mt-1">
-          Updates about your jobs will appear here as they happen.
-        </p>
+      <header className="mb-6 flex items-end justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-widest text-accent-purple-400">
+            Inbox
+          </p>
+          <h1 className="text-3xl font-semibold text-ink">Notifications</h1>
+          <p className="text-sm text-ink-muted mt-1">
+            Updates about your jobs will appear here as they happen.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void markAllRead()}
+          disabled={unreadCount === 0}
+          className="btn-ghost"
+        >
+          Mark all read
+        </button>
       </header>
-      <div className="card p-6">
-        <p className="text-sm text-ink-muted">No notifications yet.</p>
+
+      <div className="card overflow-hidden">
+        {loading && notifications.length === 0 ? (
+          <p className="p-6 text-sm text-ink-muted">Loading…</p>
+        ) : error ? (
+          <p className="p-6 text-sm text-ink-muted">
+            Couldn't load notifications.
+          </p>
+        ) : notifications.length === 0 ? (
+          <p className="p-6 text-sm text-ink-muted">No notifications yet.</p>
+        ) : (
+          notifications.map((n) => (
+            <NotificationItem
+              key={n.id}
+              notification={n}
+              now={now}
+              onClick={(id) => {
+                if (!n.readAt) void markRead(id);
+              }}
+            />
+          ))
+        )}
       </div>
     </Layout>
   );


### PR DESCRIPTION
Closes #12
Linear: https://linear.app/chuck-heya/issue/PER-13/web-notifications-inbox-bell-dropdown-polling

## Summary
Adds the authenticated notifications inbox to the web app. A bell icon lives in the header on every authenticated route, polls `GET /notifications` every 10s via a dedicated hook (cleared on unmount), and shows a dropdown of the 20 most recent items. Unread badge hides at zero. Clicking an unread item POSTs `/notifications/:id/read` and updates state optimistically. A "Mark all read" footer action fans out POSTs over the unread set. The `/inbox` page reuses the same hook so the full list and bulk mark-read work there too.

## Tests
- Added: `apps/web/src/lib/useNotifications.test.ts` (5 cases — initial fetch, disabled gate, 10s polling + unmount cleanup, optimistic markRead, markAllRead skips already-read)
- Added: `apps/web/src/components/NotificationBell.test.tsx` (4 cases — badge hidden at 0, badge + dropdown reveal, click marks read, hidden when unauthenticated)
- Status: 74 / 74 web tests passing, 50 / 50 api tests passing, both workspaces typecheck clean.

## Files touched
- `apps/web/src/lib/useNotifications.ts` — polling hook with `setInterval` + cleanup, `markRead`, `markAllRead`
- `apps/web/src/components/NotificationBell.tsx` — header bell, badge, dropdown panel with click-outside + Esc dismissal
- `apps/web/src/components/NotificationItem.tsx` — type icon, message, relative time, fades when read
- `apps/web/src/components/Layout.tsx` — mounts `<NotificationBell />` in the authenticated header
- `apps/web/src/routes/Inbox.tsx` — full inbox view using the same hook
- Test files for both new modules

## Follow-ups
- WebSocket / SSE push (out of scope per spec — polling is the documented simulation)
- Notification preferences and filtering — none planned