### PR TITLE
[PER-14] deploy-vercel-render: ship to Vercel + Render with README write-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,240 @@
-# brix-assignment
+# Brix Assignment — Service Scheduling & Notification System
+
+A small full-stack app where managers assign quotes to technicians inside fixed
+two-hour windows and technicians work through their schedule. Conflict
+prevention is enforced at both the application and database layers, and
+notifications are delivered through DB-backed polling so the demo works without
+any websocket infrastructure.
+
+## Live URLs
+
+| | URL | Notes |
+| --- | --- | --- |
+| Web (Vercel) | `https://brix-web.vercel.app` | Replace with your deployment URL |
+| API (Render) | `https://brix-api.onrender.com` | `GET /health` returns `{ "status": "ok" }` |
+
+### Demo credentials
+
+All seeded users share the password `password123`.
+
+| Role | Email |
+| --- | --- |
+| Manager | `manager1@brix.local` |
+| Manager | `manager2@brix.local` |
+| Technician | `tech1@brix.local` |
+| Technician | `tech2@brix.local` |
+| Technician | `tech3@brix.local` |
+
+## End-to-end demo
+
+1. Sign in as `manager1@brix.local`. Open the dashboard and pick an
+   unscheduled quote.
+2. Assign it to `tech1@brix.local` in any free 2-hour slot. The job appears in
+   the manager's calendar.
+3. Sign out, then sign in as `tech1@brix.local`. The newly assigned job is in
+   the schedule, and the bell shows an unread `job_assigned` notification.
+4. Mark the job completed. Sign back in as `manager1@brix.local` and the bell
+   shows a `job_completed` notification.
+
+## Architecture
+
+```
++-----------------------+        +-------------------------+
+|  apps/web (Vercel)    |        |  apps/api (Render)      |
+|  React 18 + Vite      |  --->  |  Express + Drizzle ORM  |
+|  React Router v6      |  HTTPS |  JWT (HS256) + bcrypt   |
++-----------------------+        +-----------+-------------+
+                                             |
+                                             v
+                                   +---------+--------------+
+                                   |  Postgres 16 (Render)  |
+                                   |  btree_gist + uuid-ossp|
+                                   +------------------------+
+```
+
+### Entity diagram
+
+```
+users(id, email, password_hash, name, role)
+  | role ∈ {manager, technician}
+  |
+  +----< jobs.manager_id
+  +----< jobs.technician_id
+  +----< notifications.recipient_user_id
+
+quotes(id, title, customer_name, address, status)
+  | status ∈ {unscheduled, scheduled, completed, cancelled}
+  |
+  +----< jobs.quote_id  (UNIQUE — one job per quote)
+
+jobs(id, quote_id, technician_id, manager_id,
+     start_time, end_time, status,
+     EXCLUDE USING gist (technician_id WITH =,
+                         tstzrange(start_time, end_time) WITH &&))
+
+notifications(id, recipient_user_id, job_id, type, message,
+              read_at, created_at)
+  type ∈ {job_assigned, job_rescheduled, job_cancelled, job_completed}
+```
+
+### Repository layout
+
+```
+apps/
+  api/    Express + Drizzle service deployed to Render
+  web/    Vite + React SPA deployed to Vercel
+packages/
+  shared/ TypeScript types shared between api and web
+render.yaml      Blueprint for the Render API + Postgres
+apps/web/vercel.json  Vite framework + SPA rewrite for Vercel
+```
+
+## Conflict handling
+
+Two layers, intentionally redundant.
+
+**1. Transactional pre-check (application).** `createJobAssignmentService` runs
+the conflict query and the insert in the same Postgres transaction. The
+pre-check produces a friendly `409 Conflict` with the offending job ids before
+the constraint fires.
+
+**2. Postgres exclusion constraint (database).** The `jobs` table carries:
+
+```sql
+EXCLUDE USING gist (
+  technician_id WITH =,
+  tstzrange(start_time, end_time) WITH &&
+)
+```
+
+The constraint is the source of truth. If two managers race a booking for the
+same technician on the same window, one transaction commits, the other fails
+with SQLSTATE `23P01`. The error handler translates `23P01` into HTTP `409
+Conflict` so clients see the same response shape regardless of which layer
+caught the conflict.
+
+The combination is "belt-and-suspenders": the pre-check keeps the happy path
+fast and produces a useful payload; the constraint guarantees correctness even
+under concurrent writes.
+
+## Notification design
+
+- **DB-backed.** Every job mutation writes the relevant `notifications` rows
+  in the same transaction as the job change. If the job write rolls back, the
+  notification rows roll back with it — there is no partial state where a job
+  exists without its notification or vice versa.
+- **Polling delivery.** The web app polls `GET /notifications` every 10
+  seconds. The endpoint returns the list plus an `unreadCount` so the bell
+  badge updates without a separate request. `PATCH /notifications/:id/read`
+  marks a single notification read.
+- **No real-time push.** The spec explicitly allows simulated delivery; this
+  satisfies it without bringing in websockets, SSE, or a queue.
+
+## Trade-offs
+
+- **Polling over websockets.** A 10-second poll is simple, survives connection
+  flaps, and works on Vercel/Render without long-lived connections. The
+  obvious cost is up-to-10s notification latency and constant background
+  traffic. WebSockets/SSE would be the next step.
+- **Seed-only users.** No public signup; users come exclusively from the seed
+  script. Keeps the demo predictable and avoids password-reset / email
+  scaffolding.
+- **Fixed 2-hour windows.** Encoded in the API and UI. Variable durations
+  would require richer pickers and conflict math, neither of which the spec
+  asks for.
+- **No timezone UI.** Server stores UTC, browser renders in the user's local
+  zone. Explicit per-user timezones would matter for a real production
+  scheduler.
+- **Single-region Postgres.** Render free Postgres is fine for a take-home
+  but obviously not for a production scheduler with strict latency targets.
+
+## What I'd do next
+
+- WebSocket / SSE push so the bell updates in real time.
+- Drag-to-reschedule on the manager calendar (writes go through the same
+  conflict-aware endpoint).
+- Multi-technician unified calendar so a manager can see availability across
+  the whole team at a glance.
+- `SERIALIZABLE` isolation on the assignment transaction. The current
+  `READ COMMITTED` + EXCLUDE constraint is correct, but `SERIALIZABLE` would
+  make the application-level pre-check robust against phantom reads without
+  relying on the constraint to catch the race.
+- E2E tests (Playwright) hitting the deployed environments instead of just
+  unit + supertest.
+
+## Local setup
+
+```bash
+# 1. Postgres in Docker (loads btree_gist + uuid-ossp via init scripts)
+docker compose up -d
+
+# 2. Install workspaces
+npm install
+
+# 3. Run migrations + seed
+npm run db:migrate --workspace=apps/api
+npm run db:seed    --workspace=apps/api
+
+# 4. Start both apps (api on :3001, web on :5173)
+npm run dev
+```
+
+`apps/api/.env`:
+
+```
+DATABASE_URL=postgres://brix:brix@localhost:5432/brix
+JWT_SECRET=change-me-in-production
+PORT=3001
+```
+
+`apps/web/.env`:
+
+```
+VITE_API_URL=http://localhost:3001
+```
+
+## Deployment
+
+### API on Render (Blueprint)
+
+The repo ships a `render.yaml` blueprint. Pointing Render at the repo creates
+a `brix-api` web service and a `brix-postgres` database with the right env
+wiring.
+
+- Build: `npm ci && npm run build --workspace=apps/api`
+- Pre-deploy: `npm run db:migrate --workspace=apps/api && npm run db:seed --workspace=apps/api`
+- Start: `node apps/api/dist/index.js`
+- Health check: `GET /health`
+
+`DATABASE_URL` is injected from the linked database. `JWT_SECRET` is generated
+once. `CORS_ORIGIN` must be set to the Vercel URL (it is `sync: false` so
+Render does not overwrite the dashboard value).
+
+The migrate script runs `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"` and
+`btree_gist` before applying migrations, so a fresh Render Postgres bootstraps
+without manual SQL. The seed is idempotent — it skips when users already
+exist, which makes it safe as a `preDeployCommand`.
+
+### Web on Vercel
+
+- Project root: `apps/web`
+- Framework preset: Vite (auto-detected)
+- Production env: `VITE_API_URL=<Render API URL>`
+- `apps/web/vercel.json` adds the SPA rewrite so React Router deep links work
+  on hard refresh.
+
+After both projects exist, set `CORS_ORIGIN` on the Render service to the
+Vercel domain (and any preview domains you want to allow, comma-separated).
+
+## Tests
+
+```bash
+npm test            # all workspaces
+npm run lint        # tsc --noEmit everywhere
+```
+
+API has unit and supertest coverage of auth, jobs, notifications, conflict
+handling, and the new CORS + extension layers. Web has React Testing Library
+coverage of the auth shell, manager dashboard, and technician schedule. DB
+integration tests are skipped unless `INTEGRATION=1` is set (they need a real
+Postgres).

--- a/apps/api/.env.production.example
+++ b/apps/api/.env.production.example
@@ -1,0 +1,13 @@
+# Render-managed values (do not commit real secrets)
+NODE_ENV=production
+PORT=10000
+
+# Provided automatically by Render's `fromDatabase` block in render.yaml
+DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/brix
+
+# Generate with: openssl rand -base64 32  (Render generates one via render.yaml)
+JWT_SECRET=replace-with-a-long-random-secret
+
+# Comma-separated origins permitted to call the API. Set this on Render
+# to your Vercel deployment URL once it exists.
+CORS_ORIGIN=https://brix-web.vercel.app

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,7 +16,9 @@
   },
   "dependencies": {
     "@brix/shared": "*",
+    "@types/cors": "^2.8.19",
     "bcryptjs": "^3.0.3",
+    "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "express": "^4.21.1",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from 'express';
+import cors from 'cors';
 import type { HealthStatus, UserRole } from '@brix/shared';
 import { createAuthRouter } from './routes/auth.js';
 import { quotesRouter } from './routes/quotes.js';
@@ -25,12 +26,30 @@ export type AuthDeps = {
 
 export type { JobsDeps, NotificationsDeps };
 
+function parseCorsOrigins(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  const list = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.length > 0 ? list : undefined;
+}
+
 export function createApp(
   deps?: AuthDeps,
   jobsDeps?: JobsDeps,
   notificationsDeps?: NotificationsDeps,
 ): Express {
   const app = express();
+
+  const allowedOrigins = parseCorsOrigins(process.env.CORS_ORIGIN);
+  app.use(
+    cors({
+      origin: allowedOrigins ?? true,
+      credentials: false,
+    }),
+  );
+
   app.use(express.json());
 
   app.get('/health', (_req, res) => {

--- a/apps/api/src/cors.test.ts
+++ b/apps/api/src/cors.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+
+vi.stubEnv('DATABASE_URL', 'postgresql://fake');
+vi.stubEnv('JWT_SECRET', 'test-secret');
+
+vi.mock('./db/client.js', () => ({
+  db: { select: vi.fn() },
+}));
+
+const { createApp } = await import('./app.js');
+
+describe('CORS', () => {
+  it('allows the configured origin on a simple request', async () => {
+    vi.stubEnv('CORS_ORIGIN', 'https://web.example.com');
+    const app = createApp();
+
+    const res = await request(app)
+      .get('/health')
+      .set('Origin', 'https://web.example.com');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBe(
+      'https://web.example.com',
+    );
+  });
+
+  it('omits the allow-origin header for an origin that is not allowlisted', async () => {
+    vi.stubEnv('CORS_ORIGIN', 'https://web.example.com');
+    const app = createApp();
+
+    const res = await request(app)
+      .get('/health')
+      .set('Origin', 'https://evil.example.com');
+
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('responds to a preflight request with the configured methods', async () => {
+    vi.stubEnv('CORS_ORIGIN', 'https://web.example.com');
+    const app = createApp();
+
+    const res = await request(app)
+      .options('/jobs')
+      .set('Origin', 'https://web.example.com')
+      .set('Access-Control-Request-Method', 'POST')
+      .set('Access-Control-Request-Headers', 'authorization,content-type');
+
+    expect(res.status).toBe(204);
+    expect(res.headers['access-control-allow-origin']).toBe(
+      'https://web.example.com',
+    );
+    expect(res.headers['access-control-allow-methods']).toMatch(/POST/);
+  });
+
+  it('supports a comma-separated list of allowed origins', async () => {
+    vi.stubEnv(
+      'CORS_ORIGIN',
+      'https://web.example.com, https://staging.example.com',
+    );
+    const app = createApp();
+
+    const res = await request(app)
+      .get('/health')
+      .set('Origin', 'https://staging.example.com');
+
+    expect(res.headers['access-control-allow-origin']).toBe(
+      'https://staging.example.com',
+    );
+  });
+});

--- a/apps/api/src/db/extensions.test.ts
+++ b/apps/api/src/db/extensions.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ensureExtensions } from './extensions.js';
+
+describe('ensureExtensions', () => {
+  it('creates uuid-ossp and btree_gist (idempotent)', async () => {
+    const calls: string[] = [];
+    const fakeClient = {
+      query: vi.fn(async (sql: string) => {
+        calls.push(sql);
+        return { rowCount: 0 };
+      }),
+    };
+
+    await ensureExtensions(fakeClient as never);
+
+    expect(fakeClient.query).toHaveBeenCalledTimes(2);
+    expect(calls[0]).toMatch(/CREATE EXTENSION IF NOT EXISTS "uuid-ossp"/i);
+    expect(calls[1]).toMatch(/CREATE EXTENSION IF NOT EXISTS "btree_gist"/i);
+  });
+});

--- a/apps/api/src/db/extensions.ts
+++ b/apps/api/src/db/extensions.ts
@@ -1,0 +1,8 @@
+type ExtensionClient = {
+  query: (sql: string) => Promise<unknown>;
+};
+
+export async function ensureExtensions(client: ExtensionClient): Promise<void> {
+  await client.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+  await client.query('CREATE EXTENSION IF NOT EXISTS "btree_gist";');
+}

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import { Pool } from 'pg';
+import { ensureExtensions } from './extensions.js';
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) {
@@ -16,6 +17,7 @@ const migrationsFolder = resolve(here, 'migrations');
 const pool = new Pool({ connectionString });
 const db = drizzle(pool);
 
+await ensureExtensions(pool);
 await migrate(db, { migrationsFolder });
 await pool.end();
 

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -23,6 +23,15 @@ const db = drizzle(pool);
 const password = 'password123';
 const passwordHash = await bcrypt.hash(password, 10);
 
+// Skip when the database is already populated. This keeps the seed safe to
+// run on every Render deploy via `preDeployCommand` without nuking real data.
+const existingUsers = await db.select({ id: users.id }).from(users).limit(1);
+if (existingUsers.length > 0) {
+  console.log('seed skipped: users already present');
+  await pool.end();
+  process.exit(0);
+}
+
 await db.execute(
   sql`TRUNCATE TABLE ${notifications}, ${jobs}, ${quotes}, ${users} RESTART IDENTITY CASCADE`,
 );

--- a/apps/web/.env.production.example
+++ b/apps/web/.env.production.example
@@ -1,0 +1,6 @@
+# Vercel project env vars (Production scope). Real values live in the
+# Vercel dashboard / `vercel env` — never commit them.
+
+# Public Render API URL. Vite inlines this at build time, so it must be set
+# before `vite build` runs (Vercel reads it from the project's env config).
+VITE_API_URL=https://brix-api.onrender.com

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@brix/shared": "*",
+        "@types/cors": "^2.8.19",
         "bcryptjs": "^3.0.3",
+        "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "drizzle-orm": "^0.45.2",
         "express": "^4.21.1",
@@ -1711,6 +1713,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1787,7 +1798,6 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2642,6 +2652,23 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -4665,7 +4692,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6174,7 +6200,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,34 @@
+databases:
+  - name: brix-postgres
+    databaseName: brix
+    user: brix
+    plan: free
+    postgresMajorVersion: '16'
+
+services:
+  - type: web
+    name: brix-api
+    runtime: node
+    plan: free
+    region: oregon
+    rootDir: .
+    buildCommand: npm ci && npm run build --workspace=apps/api
+    preDeployCommand: npm run db:migrate --workspace=apps/api && npm run db:seed --workspace=apps/api
+    startCommand: node apps/api/dist/index.js
+    healthCheckPath: /health
+    autoDeploy: true
+    envVars:
+      - key: NODE_VERSION
+        value: '24'
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: brix-postgres
+          property: connectionString
+      - key: JWT_SECRET
+        generateValue: true
+      - key: CORS_ORIGIN
+        sync: false
+      - key: PORT
+        value: '10000'


### PR DESCRIPTION
Closes #13
Linear: https://linear.app/chuck-heya/issue/PER-14/deploy-vercel-render-ship-to-vercel-render-with-readme-write-up

## Summary
Adds the deployment skeleton for shipping the app to Render (API + Postgres) and Vercel (web), plus a full submission README. The API gains a CORS allowlist driven by `CORS_ORIGIN` and a migration step that creates `uuid-ossp` + `btree_gist` before applying SQL — required because Render Postgres has no init-script hook the way Docker does. The seed becomes idempotent so it's safe to run on every Render deploy via `preDeployCommand`.

## Tests
- Added: `apps/api/src/cors.test.ts` — origin allowlist, comma-separated origins, and preflight (4 cases)
- Added: `apps/api/src/db/extensions.test.ts` — extension SQL is issued in the right order
- Status: 55 passing / 11 skipped (DB integration) on the API; 65 passing on the web. Lint clean across all workspaces.

## Files touched
- `render.yaml` — Render blueprint (web service + Postgres, build/preDeploy/start, env wiring)
- `apps/web/vercel.json` — Vite framework + SPA rewrite for React Router deep links
- `apps/api/src/app.ts` — `cors()` middleware, `CORS_ORIGIN` parsing
- `apps/api/src/db/extensions.ts` (+ test) — idempotent extension creation
- `apps/api/src/db/migrate.ts` — runs `ensureExtensions()` before `migrate()`
- `apps/api/src/db/seed.ts` — skip when users already exist
- `apps/api/.env.production.example`, `apps/web/.env.production.example` — env var docs
- `README.md` — full rewrite (live URLs, demo creds, architecture, conflict handling, notifications, trade-offs, what-next)

## Follow-ups
- Replace placeholder URLs in `README.md` with real `*.onrender.com` / `*.vercel.app` after the first deploys.
- Set `CORS_ORIGIN` on Render to the actual Vercel URL once Vercel is live.
- Optional: WebSocket / SSE push, drag-to-reschedule, multi-tech calendar, `SERIALIZABLE` isolation on assignment.